### PR TITLE
Add job waitfor step

### DIFF
--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python -u
+import logging
+import sys
+import common
+import time
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from os import environ
+
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.INFO,
+    format="%(levelname)s: %(name)s: %(message)s"
+)
+log = logging.getLogger("kubernetes-wait-job")
+
+
+def wait():
+    try:
+        name = environ.get("RD_CONFIG_NAME")
+        namespace = environ.get("RD_CONFIG_NAMESPACE")
+        retries = int(environ.get("RD_CONFIG_RETRIES"))
+        sleep = float(environ.get("RD_CONFIG_SLEEP"))
+        show_log = environ.get("RD_CONFIG_SHOW_LOG") == "true"
+
+        batch_v1 = client.BatchV1Api()
+        core_v1 = client.CoreV1Api()
+
+        log.debug("Checking job status")
+        api_response = batch_v1.read_namespaced_job_status(
+            name,
+            namespace,
+            pretty="True"
+        )
+        log.debug(api_response)
+
+        # Poll for completion if retries
+        retries_count = 0
+        while not api_response.status.completion_time:
+            retries_count = retries_count + 1
+            if retries_count > retries:
+                log.error("Number of retries exceeded")
+                sys.exit(1)
+
+            log.info("Wating for job completion")
+            time.sleep(sleep)
+            api_response = batch_v1.read_namespaced_job_status(
+                name,
+                namespace,
+                pretty="True"
+            )
+
+        if show_log:
+            log.debug("Searching for pod associated with job")
+            pod_list = core_v1.list_namespaced_pod(
+                namespace,
+                label_selector="job-name==" + name
+            )
+            first_item = pod_list.items[0]
+            pod_name = first_item.metadata.name
+            log.debug("Fetching logs from pod: {0}".format(pod_name))
+            pod_log = core_v1.read_namespaced_pod_log(pod_name, namespace)
+
+            log.info("========================== job log start ==========================")
+            log.info(pod_log)
+            log.info("=========================== job log end ===========================")
+
+        if api_response.status.succeeded:
+            log.info("Job succeeded")
+            sys.exit(0)
+        else:
+            log.info("Job failed")
+            sys.exit(1)
+
+    except ApiException as e:
+        log.error("Exception waiting for job: %s\n" % e)
+        sys.exit(1)
+
+
+def main():
+    if environ.get("RD_CONFIG_DEBUG") == "true":
+        log.setLevel(logging.DEBUG)
+        log.debug("Log level configured for DEBUG")
+
+    common.connect()
+    wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1583,6 +1583,89 @@ providers:
         required: false
         renderingOptions:
           groupName: Config
+  - name: Kubernetes-Wait-Job
+    service: WorkflowNodeStep
+    title: Kubernetes / Job / Waitfor
+    description: 'Waitfor Job'
+    plugin-type: script
+    script-interpreter: python -u
+    script-file: job-wait.py
+    script-args:
+    config:
+      - name: name
+        type: String
+        title: "Name"
+        description: "Job Name"
+        required: true
+      - name: namespace
+        type: String
+        title: "Namespace"
+        default: "default"
+        description: "Namespace where the job was created"
+        required: true
+      - name: retries
+        type: String
+        title: "Retries"
+        default: "100"
+        description: "Number of retries"
+        required: true
+      - name: sleep
+        type: String
+        title: "Sleep"
+        default: "10"
+        description: "Sleep between retries"
+        required: true
+      - name: show_log
+        type: Boolean
+        title: "Show Log"
+        default: true
+        description: "Show job log from kubernetes"
+        required: false
+      - name: config_file
+        type: String
+        title: "Kubernetes Config File Path"
+        description: "Leave empty if you want to pass the connection parameters"
+        required: false
+        renderingOptions:
+          groupName: Authentication
+      - name: url
+        type: String
+        title: "Cluster URL"
+        description: "Kubernetes Cluster URL"
+        required: false
+        renderingOptions:
+          groupName: Authentication
+      - name: token
+        type: String
+        title: "Token"
+        required: false
+        description: "Kubernetes API Token"
+        renderingOptions:
+          groupName: Authentication
+          selectionAccessor: "STORAGE_PATH"
+          valueConversion: "STORAGE_PATH_AUTOMATIC_READ"
+          storage-path-root: "keys"
+      - name: verify_ssl
+        type: Boolean
+        title: "Verify ssl"
+        description: "Verify ssl for SSL connections"
+        required: false
+        renderingOptions:
+          groupName: Authentication
+      - name: ssl_ca_cert
+        type: String
+        title: "SSL Certificate Path"
+        description: "SSL Certificate Path for SSL connections"
+        required: false
+        renderingOptions:
+          groupName: Authentication
+      - type: Boolean
+        name: debug
+        title: Debug?
+        description: "Write debug messages to stderr"
+        required: false
+        renderingOptions:
+          groupName: Config
   - name: Kubernetes-Pods-Logs
     service: WorkflowNodeStep
     title: Kubernetes / Pods / Logs


### PR DESCRIPTION
The current k8s job create step does not wait for the
job to finish executing.

This new step allows waiting for job completion
and optionally reporting the k8s job logs.

Fixes #9  

![image](https://user-images.githubusercontent.com/546259/42853750-ae9db4d6-89f5-11e8-94a7-6b21c919d39b.png)

