### PR TITLE
Add Annotations to Job Create + make pod inherit Labels and Annotations

### DIFF
--- a/contents/job-create.py
+++ b/contents/job-create.py
@@ -17,11 +17,13 @@ log = logging.getLogger('kubernetes-model-source')
 def create_job_object(data):
     meta = client.V1ObjectMeta(name=data["name"], namespace=data["namespace"])
 
+    labels = None
     if "labels" in data:
         labels_array = data["labels"].split(',')
         labels = dict(s.split('=') for s in labels_array)
         meta.labels = labels
 
+    annotations = None
     if "annotations" in data:
         annotations_array = data["annotations"].split(',')
         annotations = dict(s.split('=') for s in annotations_array)

--- a/contents/job-create.py
+++ b/contents/job-create.py
@@ -22,6 +22,11 @@ def create_job_object(data):
         labels = dict(s.split('=') for s in labels_array)
         meta.labels = labels
 
+    if "annotations" in data:
+        annotations_array = data["annotations"].split(',')
+        annotations = dict(s.split('=') for s in annotations_array)
+        meta.annotations = annotations
+
     envs = []
     if "environments" in data:
         envs_array = data["environments"].splitlines()
@@ -115,7 +120,9 @@ def create_job_object(data):
 
     template = client.V1PodTemplateSpec(
         metadata=client.V1ObjectMeta(
-                    name=data["name"]
+                    name=data["name"],
+                    labels=labels,
+                    annotations=annotations,
                 ),
         spec=template_spec
     )
@@ -165,6 +172,9 @@ def main():
 
     if os.environ.get('RD_CONFIG_LABELS'):
         data["labels"] = os.environ.get('RD_CONFIG_LABELS')
+
+    if os.environ.get('RD_CONFIG_ANNOTATIONS'):
+        data["annotations"] = os.environ.get('RD_CONFIG_ANNOTATIONS')
 
     if os.environ.get('RD_CONFIG_SELECTORS'):
         data["selectors"] = os.environ.get('RD_CONFIG_SELECTORS')

--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -45,7 +45,7 @@ def wait():
 
             if api_response.status.conditions:
                 for condition in api_response.status.conditions:
-                    if condition['type'] == "Failed":
+                    if condition.type == "Failed":
                         completed = True
 
             if api_response.status.completion_time:

--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -43,9 +43,10 @@ def wait():
                 log.error("Number of retries exceeded")
                 completed = True
 
-            for condition in api_response.status.conditions:
-                if condition['type'] == "Failed":
-                    completed = True
+            if api_response.status.conditions:
+                for condition in api_response.status.conditions:
+                    if condition['type'] == "Failed":
+                        completed = True
 
             if api_response.status.completion_time:
                 completed = True

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1481,6 +1481,7 @@ providers:
         required: false
         renderingOptions:
           groupName: Container
+          displayType: MULTI_LINE
       - name: resources_requests
         type: String
         title: "Resource Requests"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1386,6 +1386,13 @@ providers:
         required: false
         renderingOptions:
           groupName: Metadata
+      - name: annotations
+        type: String
+        title: "Annotations"
+        description: "Annotations. Add a comma separeted values (key=value format)"
+        required: false
+        renderingOptions:
+          groupName: Metadata
       - name: selectors
         type: String
         title: "Selectors"


### PR DESCRIPTION
Right now you cannot set annotations, and the pod created from a job doesn't inherit labels/annotations.

We need the pod to inherit annotations because we run Rundeck on Kubernetes+AWS, and we use Kube2iam to assign IAM Roles to pods (which make uses of Pod annotations). Also, if the pod inherit labels it is easier to list/delete using the -l flag, and also it is easier to find logs for a certain pod on ElasticSearch.

I may do this also with the others resources (Deployments, raw Pods,...) if you think it will be merge.