### PR TITLE
job-wait to detect when the job has failed

### DIFF
--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -27,29 +27,35 @@ def wait():
         batch_v1 = client.BatchV1Api()
         core_v1 = client.CoreV1Api()
 
-        log.debug("Checking job status")
-        api_response = batch_v1.read_namespaced_job_status(
-            name,
-            namespace,
-            pretty="True"
-        )
-        log.debug(api_response)
-
         # Poll for completion if retries
         retries_count = 0
-        while not api_response.status.completion_time:
-            retries_count = retries_count + 1
-            if retries_count > retries:
-                log.error("Number of retries exceeded")
-                sys.exit(1)
-
-            log.info("Wating for job completion")
-            time.sleep(sleep)
+        completed = False
+        while True:
             api_response = batch_v1.read_namespaced_job_status(
                 name,
                 namespace,
                 pretty="True"
             )
+            log.debug(api_response)
+
+            retries_count = retries_count + 1
+            if retries_count > retries:
+                log.error("Number of retries exceeded")
+                completed = True
+
+            if api_response.status.conditions:
+                for condition in api_response.status.conditions:
+                    if condition.type == "Failed":
+                        completed = True
+
+            if api_response.status.completion_time:
+                completed = True
+
+            if completed:
+                break
+
+            log.info("Wating for job completion")
+            time.sleep(sleep)
 
         if show_log:
             log.debug("Searching for pod associated with job")


### PR DESCRIPTION
This PR fixes  job-wait not detecting if the job has failed. Either if it has failed, completed, or reached max tries we do always attach the output for further debugging.