### PR TITLE
Inline script step fails on Kubernetes pod node #38

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -355,12 +355,12 @@ def create_pod_template_spec(data):
     return template_spec
 
 
-def copy_file(name, container, source_file, destination_path, destination_file_name, stdout = False):
+def copy_file(name, namespace, container, source_file, destination_path, destination_file_name, stdout = False):
     api = core_v1_api.CoreV1Api()
 
     # Copying file client -> pod
     exec_command = ['tar', 'xvf', '-', '-C', '/']
-    resp = stream(api.connect_get_namespaced_pod_exec, name, 'default',
+    resp = stream(api.connect_get_namespaced_pod_exec, name, namespace,
                   command=exec_command,
                   container=container,
                   stderr=False, stdin=True,

--- a/contents/pods-copy-file.py
+++ b/contents/pods-copy-file.py
@@ -62,7 +62,7 @@ def main():
     destination_path = os.path.dirname(destination_file)
     destination_file_name = os.path.basename(destination_file)
 
-    common.copy_file(name, container, source_file, destination_path, destination_file_name)
+    common.copy_file(name, namespace, container, source_file, destination_path, destination_file_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should fix the script execution inside a pod not in 'default' namespace