### PR TITLE
add namespace to script copy when using pod-run-script

### DIFF
--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -82,6 +82,7 @@ def main():
         log.debug("coping script from %s to %s" % (temp.name,full_path))
 
         common.copy_file(name=name,
+                         namespace=namespace,
                          container=container,
                          source_file=temp.name,
                          destination_path= destination_path,


### PR DESCRIPTION
failing when using "Kubernetes / Pods / Execute Script" while copying script into pod
> 	Traceback (most recent call last):
> 	  File "pods-run-script.py", line 156, in <module>
> 	    main()
> 	  File "pods-run-script.py", line 88, in main
> 	    destination_file_name=destination_file_name
> 	TypeError: copy_file() takes at least 6 arguments (5 given)
> 	Failed: NonZeroResultCode: Script result code was: 1