### PR TITLE
pods-wait.py - Fixed initial value of status

### DIFF
--- a/contents/pods-wait.py
+++ b/contents/pods-wait.py
@@ -36,7 +36,7 @@ def wait():
         )
         log.debug(api_response.status)
 
-        status = None
+        status = False
 
         if api_response.status.container_statuses:
            status = api_response.status.container_statuses[0].ready


### PR DESCRIPTION
As the loop to wait for pod startup continues `while status == False` it would exit immidiately because the initial value is None. Set the initial value to False.

Maybe I'm overlooking something, but this fix worked for me.