### PR TITLE
Get error from kubernetes response

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -443,7 +443,16 @@ def run_interactive_command(name, namespace, container, command):
             print("%s" % resp.read_stdout())
         if resp.peek_stderr():
             log.error("%s" % resp.read_stderr())
-            error = True
+
+    ERROR_CHANNEL = 3
+    err = api.api_client.last_response.read_channel(ERROR_CHANNEL)
+    err = yaml.safe_load(err)
+    if err['status'] != "Success":
+        log.error('Failed to run command')
+        log.error('Reason: ' + err['reason'])
+        log.error('Message: ' + err['message'])
+        log.error('Details: ' + ';'.join(map(lambda x: json.dumps(x), err['details']['causes'])))
+        error = True
 
     return (resp,error)
 


### PR DESCRIPTION
## Expected behavior
Fail step when exit code != 0

## Actual behavior
Step marked as OK even if exit code != 0

## Solution
To check error, returned by kubernetes

Error checking code stealed from latest version of kubernetes-client/python-base:
https://github.com/kubernetes-client/python-base/blob/6b6546131217a2a9fdcf431a286c346619d2923a/stream/ws_client.py#L215

I'm not a python developer so code can be not perfect
May be it will be useful to add code like this in other connect_get_namespaced_pod_exec calls (like in run_command) but I not sure how to do it correctly