### PR TITLE
Bug correction - enabling pods-wait to show logs of  a pod containing…

### DIFF
--- a/contents/pods-wait.py
+++ b/contents/pods-wait.py
@@ -63,15 +63,18 @@ def wait():
             log.debug(api_response.status.container_statuses)
 
         if show_log:
-            log.debug("Fetching logs from pod: {0}".format(name))
-            pod_log = core_v1.read_namespaced_pod_log(
-                name=name,
-                namespace=namespace
-            )
+            for i in range(len(api_response.status.container_statuses)):
+                log.debug("Fetching logs from pod: {0}    -- container {1}".format(name,api_response.status.container_statuses[i].name))
+                log.info("Fetching logs from pod: {0}    -- container {1} ".format(name,api_response.status.container_statuses[i].name))
+                pod_log = core_v1.read_namespaced_pod_log(
+                    name=name,
+                    namespace=namespace,
+                    container=api_response.status.container_statuses[i].name
+                )
 
-            print("========================== job log start ==========================")
-            print(pod_log)
-            print("=========================== job log end ===========================")
+                print("========================== job log start ==========================")
+                print(pod_log)
+                print("=========================== job log end ===========================")
 
         if status:
             print("Pod ready")

--- a/contents/pods-wait.py
+++ b/contents/pods-wait.py
@@ -64,7 +64,6 @@ def wait():
 
         if show_log:
             for i in range(len(api_response.status.container_statuses)):
-                log.debug("Fetching logs from pod: {0}    -- container {1}".format(name,api_response.status.container_statuses[i].name))
                 log.info("Fetching logs from pod: {0}    -- container {1} ".format(name,api_response.status.container_statuses[i].name))
                 pod_log = core_v1.read_namespaced_pod_log(
                     name=name,


### PR DESCRIPTION
… multiple containers

Before this patch if you execute pods-wait on a pod containing multiple pods you will have the following error: ( show_log must be enabled to have this error )

15:01:43		Wating for pod completion ... 
15:01:53		ERROR: kubernetes-wait-pod: Exception waiting for job: (400)
15:01:53		Reason: Bad Request
15:01:53		HTTP response headers: HTTPHeaderDict({'Date': 'Fri, 14 Feb 2020 14:01:53 GMT', 'Content-Length': '216', 'Content-Type': 'application/json'})
15:01:53		HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"a container name must be specified for pod ansiblerundeckrunner-0, choose one of: [nginx dind-daemon]","reason":"BadRequest","code":400}