### PR TITLE
fix pod status filter

### DIFF
--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -224,7 +224,7 @@ def main():
                     node_set.append(node_data)
 
             if running is True:
-                if node_data["status"] == "Running":
+                if node_data["status"].lower() == "running":
                     node_set.append(node_data)
 
     print(json.dumps(node_set, indent=4, sort_keys=True))


### PR DESCRIPTION
Problem:
node_set variable is empty

Not sure if this is a case for all the k8s clusters, but fixed my problem on EKS running kubernetes version 1.15