### PR TITLE
Added support for openshift buildconfig

### DIFF
--- a/contents/create-from-yaml.py
+++ b/contents/create-from-yaml.py
@@ -137,7 +137,7 @@ def main():
             openshift_client = DynamicClient(k8s_client)
             v1_bc = openshift_client.resources.get(api_version='build.openshift.io/v1', kind='BuildConfig')
 
-            resp = v1_bc.create(body=dep, namespace='default')
+            resp = v1_bc.create(body=dep, namespace=data["namespace"])
 
             print(common.parseJson(resp.metadata))
     except ApiException as e:

--- a/contents/create-from-yaml.py
+++ b/contents/create-from-yaml.py
@@ -5,9 +5,9 @@ import os
 import yaml
 import common
 
-from kubernetes import client
+from kubernetes import client, config
 from kubernetes.client.rest import ApiException
-
+from openshift.dynamic import DynamicClient
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
@@ -130,6 +130,16 @@ def main():
 
             print(common.parseJson(resp.status))
 
+        if data["type"] == "BuildConfig":
+            dep = yaml.safe_load(data["yaml"])
+
+            k8s_client = config.new_client_from_config()
+            openshift_client = DynamicClient(k8s_client)
+            v1_bc = openshift_client.resources.get(api_version='build.openshift.io/v1', kind='BuildConfig')
+
+            resp = v1_bc.create(body=dep, namespace='default')
+
+            print(common.parseJson(resp.metadata))
     except ApiException as e:
         log.error("Exception error creating: %s\n" % e)
         sys.exit(1)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -902,7 +902,7 @@ providers:
         title: "Type"
         description: "Type"
         required: true
-        values: Deployment,StatefulSet,ConfigMap,Service,Ingress,Job,StorageClass,PersistentVolume,PersistentVolumeClaim,Secret
+        values: Deployment,StatefulSet,ConfigMap,Service,Ingress,Job,StorageClass,PersistentVolume,PersistentVolumeClaim,Secret,BuildConfig
       - name: yaml
         type: String
         title: "YAML String"


### PR DESCRIPTION
This adds support to creating `BuildConfig` objects in an Openshift cluster. 

This will require an additional python plugin for openshift support (https://github.com/openshift/openshift-restclient-python).  Let me know if you want to accept this PR. I can work on any modifications if necessary. 

Ref: #87 