### PR TITLE
Use node information for pod commands when fields are left unspecified

### DIFF
--- a/contents/pods-copy-file.py
+++ b/contents/pods-copy-file.py
@@ -28,14 +28,14 @@ def main():
     common.connect()
     api = core_v1_api.CoreV1Api()
 
-    name = os.environ.get('RD_NODE_DEFAULT_NAME')
-    namespace = os.environ.get('RD_NODE_DEFAULT_NAMESPACE')
+    name = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
+    namespace = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
     container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s" % name)
-    log.debug("Namespace: %s " % namespace)
-    log.debug("Container: %s " % container)
+    log.debug("Pod Name:  %s", name)
+    log.debug("Namespace: %s", namespace)
+    log.debug("Container: %s", container)
     log.debug("--------------------------")
 
     resp = None

--- a/contents/pods-copy-file.py
+++ b/contents/pods-copy-file.py
@@ -33,9 +33,9 @@ def main():
     container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s", name)
-    log.debug("Namespace: %s", namespace)
-    log.debug("Container: %s", container)
+    log.debug("Pod Name:  %s" % name)
+    log.debug("Namespace: %s " % namespace)
+    log.debug("Container: %s " % container)
     log.debug("--------------------------")
 
     resp = None

--- a/contents/pods-create.py
+++ b/contents/pods-create.py
@@ -53,9 +53,9 @@ def main():
     container = os.environ.get('RD_CONFIG_CONTAINER_NAME')
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s" % name)
-    log.debug("Namespace: %s " % namespace)
-    log.debug("Container: %s " % container)
+    log.debug("Pod Name:  %s", name)
+    log.debug("Namespace: %s", namespace)
+    log.debug("Container: %s", container)
     log.debug("--------------------------")
 
     data = {}

--- a/contents/pods-create.py
+++ b/contents/pods-create.py
@@ -53,9 +53,9 @@ def main():
     container = os.environ.get('RD_CONFIG_CONTAINER_NAME')
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s", name)
-    log.debug("Namespace: %s", namespace)
-    log.debug("Container: %s", container)
+    log.debug("Pod Name:  %s" % name)
+    log.debug("Namespace: %s " % namespace)
+    log.debug("Container: %s " % container)
     log.debug("--------------------------")
 
     data = {}

--- a/contents/pods-delete.py
+++ b/contents/pods-delete.py
@@ -33,8 +33,8 @@ def main():
 
     data = {}
 
-    data["name"] = os.environ.get('RD_CONFIG_NAME')
-    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE')
+    data["name"] = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
+    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
 
     common.connect()
 

--- a/contents/pods-node-executor.py
+++ b/contents/pods-node-executor.py
@@ -24,14 +24,12 @@ def main():
     name = None
     namespace = None
 
-    if 'RD_NODE_DEFAULT_NAME' in os.environ and 'RD_NODE_DEFAULT_NAME' and 'RD_NODE_DEFAULT_CONTAINER_NAME' in os.environ:
-        namespace = os.environ.get('RD_NODE_DEFAULT_NAMESPACE')
-        name = os.environ.get('RD_NODE_DEFAULT_NAME')
+    name = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
+    namespace = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
+
+    if 'RD_NODE_DEFAULT_CONTAINER_NAME' in os.environ:
         container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
     else:
-        namespace = os.environ.get('RD_CONFIG_NAMESPACE')
-        name = os.environ.get('RD_CONFIG_NAME')
-
         core_v1 = client.CoreV1Api()
         response = core_v1.read_namespaced_pod_status(
             name=name,
@@ -41,9 +39,9 @@ def main():
         container = response.spec.containers[0].name
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s" % name)
-    log.debug("Namespace: %s " % namespace)
-    log.debug("Container: %s " % container)
+    log.debug("Pod Name:  %s", name)
+    log.debug("Namespace: %s", namespace)
+    log.debug("Container: %s", container)
     log.debug("--------------------------")
 
     resp = None

--- a/contents/pods-node-executor.py
+++ b/contents/pods-node-executor.py
@@ -39,9 +39,9 @@ def main():
         container = response.spec.containers[0].name
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s", name)
-    log.debug("Namespace: %s", namespace)
-    log.debug("Container: %s", container)
+    log.debug("Pod Name:  %s" % name)
+    log.debug("Namespace: %s " % namespace)
+    log.debug("Container: %s " % container)
     log.debug("--------------------------")
 
     resp = None

--- a/contents/pods-read-logs.py
+++ b/contents/pods-read-logs.py
@@ -19,8 +19,8 @@ def main():
         log.debug("Log level configured for DEBUG")
 
     data = {}
-    data["name"] = os.environ.get('RD_CONFIG_NAME')
-    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE')
+    data["name"] = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
+    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
     data["container"] = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
     data["follow"] = os.environ.get('RD_CONFIG_FOLLOW')
 

--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -24,12 +24,14 @@ def main():
     common.connect()
 
     api = core_v1_api.CoreV1Api()
-    namespace = os.environ.get('RD_CONFIG_NAMESPACE')
-    name = os.environ.get('RD_CONFIG_NAME')
+    name = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
+    namespace = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
+    container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s" % name)
-    log.debug("Namespace: %s " % namespace)
+    log.debug("Pod Name:  %s", name)
+    log.debug("Namespace: %s", namespace)
+    log.debug("Container: %s", container)
     log.debug("--------------------------")
 
     delete_on_fail = False

--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -29,9 +29,8 @@ def main():
     container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
 
     log.debug("--------------------------")
-    log.debug("Pod Name:  %s", name)
-    log.debug("Namespace: %s", namespace)
-    log.debug("Container: %s", container)
+    log.debug("Pod Name:  %s" % name)
+    log.debug("Namespace: %s " % namespace)
     log.debug("--------------------------")
 
     delete_on_fail = False

--- a/contents/pods-wait.py
+++ b/contents/pods-wait.py
@@ -20,8 +20,8 @@ if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
 
 def wait():
     try:
-        name = environ.get("RD_CONFIG_NAME")
-        namespace = environ.get("RD_CONFIG_NAMESPACE")
+        name = environ.get('RD_CONFIG_NAME', environ.get('RD_NODE_DEFAULT_NAME'))
+        namespace = environ.get('RD_CONFIG_NAMESPACE', environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
         retries = int(environ.get("RD_CONFIG_RETRIES"))
         sleep = float(environ.get("RD_CONFIG_SLEEP"))
         show_log = environ.get("RD_CONFIG_SHOW_LOG") == "true"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1853,13 +1853,12 @@ providers:
         type: String
         title: "Name"
         description: "Pod Name"
-        required: true
+        required: false
       - name: namespace
         type: String
         title: "Namespace"
-        default: "default"
-        description: "Namespace where the deployment will be created "
-        required: true
+        description: "Namespace where the pod was created"
+        required: false
       - type: Boolean
         name: follow
         title: Follow Output
@@ -2109,13 +2108,12 @@ providers:
         type: String
         title: "Name"
         description: "Pod Name"
-        required: true
+        required: fals
       - name: namespace
         type: String
         title: "Namespace"
-        default: "default"
-        description: "Namespace where the pod will be created "
-        required: true
+        description: "Namespace where the pod was created"
+        required: false
       - name: config_file
         type: String
         title: "Kubernetes Config File Path"
@@ -2172,13 +2170,13 @@ providers:
         type: String
         title: "Name"
         description: "Job Name"
-        required: true
+        required: false
       - name: namespace
         type: String
         title: "Namespace"
         default: "default"
-        description: "Namespace where the job was created"
-        required: true
+        description: "Namespace where the pod was created"
+        required: delete
       - name: retries
         type: String
         title: "Retries"
@@ -2253,13 +2251,12 @@ providers:
         type: String
         title: "Pod Name"
         description: "Pod Name"
-        required: true
+        required: false
       - name: namespace
         type: String
         title: "Namespace"
-        default: "default"
-        description: "Namespace where the job was created"
-        required: true
+        description: "Namespace where the pod was created"
+        required: false
       - name: shell
         type: String
         title: "Shell"
@@ -2327,13 +2324,12 @@ providers:
         type: String
         title: "Pod Name"
         description: "Pod Name"
-        required: true
+        required: false
       - name: namespace
         type: String
         title: "Namespace"
-        default: "default"
         description: "Namespace where the job was created"
-        required: true
+        required: false
       - name: script
         type: String
         title: "Script"


### PR DESCRIPTION
In many cases, the correct node information is (name and namespace) is in the node context. Use that instead of requiring users to manually enter the information. Preserve the ability to specify node manually, especially for the case where a pod is created at the beginning of a job with a specified name that will then flow through the entire workflow.