### PR TITLE
Add some tests for functions in common.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/venv/
+/.pytest_cache/
+
 # Created by https://www.gitignore.io/api/java,gradle
 
 

--- a/contents/common.py
+++ b/contents/common.py
@@ -12,6 +12,7 @@ from kubernetes import client, config
 from kubernetes.client import Configuration
 from kubernetes.stream import stream
 from kubernetes.client.api import core_v1_api
+from kubernetes.client.rest import ApiException
 
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -134,6 +135,63 @@ def load_liveness_readiness_probe(data):
         v1Probe.timeout_seconds = probe["timeoutSeconds"]
 
     return v1Probe
+
+
+def get_core_node_parameter_list():
+    """
+    Finds pod and container request info.
+
+    For pod name and namespace, looks for an explicitly specified value in the
+    step definition, and uses the node value if no explicit setting is found.
+    When creating nodes, uses 'default' as the namespace when one is not
+    specified.
+
+    :returns: A list of name, namespace, and container
+    """
+    data = get_code_node_parameter_dictionary()
+    return [data['name'], data['namespace'], data['container_name']]
+
+
+def get_code_node_parameter_dictionary():
+    """
+    Finds pod and container request info.
+
+    For pod name and namespace, looks for an explicitly specified value in the
+    step definition, and uses the node value if no explicit setting is found.
+    When creating nodes, uses 'default' as the namespace when one is not
+    specified.
+
+    :returns: A dictionary of name, namespace, and container
+    """
+    return {
+        'name': os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME')),
+        'namespace': os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default')),
+        'container_name': os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
+    }
+
+
+def log_pod_parameters(logger, data):
+    """Writes debug-level log for a pod."""
+    logger.debug("--------------------------")
+    logger.debug("Pod Name:  %s", data['name'])
+    logger.debug("Namespace: %s", data['namespace'])
+    logger.debug("Container: %s", data['container_name'])
+    logger.debug("--------------------------")
+
+
+def verify_pod_exists(name, namespace):
+    """Verify pod exists."""
+    api = core_v1_api.CoreV1Api()
+    resp = None
+    try:
+        resp = api.read_namespaced_pod(name=name, namespace=namespace)
+    except ApiException as e:
+        if e.status != 404:
+            log.exception("Unknown error:")
+            exit(1)
+    if not resp:
+        log.error("Pod %s does not exist", name)
+        exit(1)
 
 
 def parsePorts(data):
@@ -270,6 +328,7 @@ def parseJson(obj):
         return json.dumps(obj, cls=ObjectEncoder)
     except:
         return obj
+
 
 def create_pod_template_spec(data):
     ports = []
@@ -495,7 +554,8 @@ def run_interactive_command(name, namespace, container, command):
     return (resp, error)
 
 
-def delete_pod(api, data):
+def delete_pod(data):
+    api = core_v1_api.CoreV1Api()
     body = client.V1DeleteOptions()
 
     try:
@@ -505,7 +565,6 @@ def delete_pod(api, data):
                                          body=body,
                                          grace_period_seconds=5,
                                          propagation_policy='Foreground')
-
         return resp
 
     except Exception as e:

--- a/contents/pods-copy-file.py
+++ b/contents/pods-copy-file.py
@@ -6,9 +6,6 @@ import common
 import logging
 
 
-from kubernetes.client.api import core_v1_api
-from kubernetes.client.rest import ApiException
-
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
 log = logging.getLogger('kubernetes-model-source')
@@ -26,35 +23,15 @@ args = parser.parse_args()
 def main():
 
     common.connect()
-    api = core_v1_api.CoreV1Api()
 
-    name = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
-    namespace = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
-    container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
-
-    log.debug("--------------------------")
-    log.debug("Pod Name:  %s", name)
-    log.debug("Namespace: %s", namespace)
-    log.debug("Container: %s", container)
-    log.debug("--------------------------")
-
-    resp = None
-    try:
-        resp = api.read_namespaced_pod(name=name,
-                                       namespace=namespace)
-    except ApiException as e:
-        if e.status != 404:
-            log.exception("Unknown error:")
-            exit(1)
-
-    if not resp:
-        log.error("Pod %s does not exist", name)
-        exit(1)
+    [name, namespace, container] = common.get_core_node_parameter_list()
+    common.log_pod_parameters(log, {'name': name, 'namespace': namespace, 'container_name': container})
+    common.verify_pod_exists(name, namespace)
 
     source_file = os.environ.get('RD_FILE_COPY_FILE')
     destination_file = os.environ.get('RD_FILE_COPY_DESTINATION')
 
-    #force print destination to avoid error with node-executor
+    # force print destination to avoid error with node-executor
     print(destination_file)
 
     log.debug("Copying file from %s to %s", source_file, destination_file)

--- a/contents/pods-create.py
+++ b/contents/pods-create.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python -u
-import argparse
 import logging
 import sys
 import os
@@ -40,33 +39,19 @@ def create_pod(data):
     return pod
 
 
-
-
 def main():
 
     common.connect()
 
     api = core_v1_api.CoreV1Api()
 
-    namespace = os.environ.get('RD_CONFIG_NAMESPACE')
-    name = os.environ.get('RD_CONFIG_NAME')
-    container = os.environ.get('RD_CONFIG_CONTAINER_NAME')
-
-    log.debug("--------------------------")
-    log.debug("Pod Name:  %s", name)
-    log.debug("Namespace: %s", namespace)
-    log.debug("Container: %s", container)
-    log.debug("--------------------------")
-
-    data = {}
+    data = common.get_code_node_parameter_dictionary()
+    common.log_pod_parameters(log, data)
 
     data["api_version"] = os.environ.get('RD_CONFIG_API_VERSION')
-    data["name"] = os.environ.get('RD_CONFIG_NAME')
-    data["container_name"] = os.environ.get('RD_CONFIG_CONTAINER_NAME')
     data["image"] = os.environ.get('RD_CONFIG_IMAGE')
     data["ports"] = os.environ.get('RD_CONFIG_PORTS')
     data["replicas"] = os.environ.get('RD_CONFIG_REPLICAS')
-    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE')
     data["labels"] = os.environ.get('RD_CONFIG_LABELS')
     if os.environ.get('RD_CONFIG_ENVIRONMENTS'):
         data["environments"] = os.environ.get('RD_CONFIG_ENVIRONMENTS')
@@ -107,7 +92,7 @@ def main():
     pod = create_pod(data)
     resp = None
     try:
-        resp = api.create_namespaced_pod(namespace=namespace,
+        resp = api.create_namespaced_pod(namespace=data['namespace'],
                                          body=pod,
                                          pretty="True")
 
@@ -118,7 +103,7 @@ def main():
         exit(1)
 
     if not resp:
-        print("Pod %s does not exist" % name)
+        print("Pod %s does not exist" % data['name'])
         exit(1)
 
 

--- a/contents/pods-delete.py
+++ b/contents/pods-delete.py
@@ -4,10 +4,7 @@ import sys
 import os
 import common
 
-from kubernetes import client
 from kubernetes.client.rest import ApiException
-from kubernetes.client.api import core_v1_api
-
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
@@ -17,29 +14,19 @@ if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log.setLevel(logging.DEBUG)
 
 
-def delete_pod(data):
-    # Delete pod
-    api = core_v1_api.CoreV1Api()
-    common.delete_pod(api, data)
-
-    print("Pod deleted successfully")
-
-
 def main():
 
     if os.environ.get('RD_CONFIG_DEBUG') == 'true':
         log.setLevel(logging.DEBUG)
         log.debug("Log level configured for DEBUG")
 
-    data = {}
-
-    data["name"] = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
-    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
+    data = common.get_code_node_parameter_dictionary()
 
     common.connect()
 
     try:
-        delete_pod(data)
+        common.delete_pod(data)
+        print("Pod deleted successfully")
     except ApiException:
         log.exception("Exception deleting deployment:")
         sys.exit(1)

--- a/contents/pods-read-logs.py
+++ b/contents/pods-read-logs.py
@@ -18,10 +18,7 @@ def main():
         log.setLevel(logging.DEBUG)
         log.debug("Log level configured for DEBUG")
 
-    data = {}
-    data["name"] = os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME'))
-    data["namespace"] = os.environ.get('RD_CONFIG_NAMESPACE', os.environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
-    data["container"] = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
+    data = common.get_code_node_parameter_dictionary()
     data["follow"] = os.environ.get('RD_CONFIG_FOLLOW')
 
     common.connect()
@@ -34,23 +31,24 @@ def main():
             if data["container"]:
                 w = watch.Watch()
                 for line in w.stream(v1.read_namespaced_pod_log,
-                                     name=data["name"],
                                      namespace=data["namespace"],
+                                     name=data["name"],
                                      follow=False):
                     print(line)
             else:
                 w = watch.Watch()
-                for line in w.stream(v1.read_namespaced_pod_log, name=data["name"],
-                                     container=data["container"],
+                for line in w.stream(v1.read_namespaced_pod_log,
+                                     container=data["container_name"],
                                      namespace=data["namespace"],
+                                     name=data["name"],
                                      follow=False):
                     print(line)
         else:
             if data["container"]:
                 ret = v1.read_namespaced_pod_log(
+                    container=data["container_name"],
                     namespace=data["namespace"],
                     name=data["name"],
-                    container=data["container"],
                     _preload_content=False
                 )
             else:

--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -55,7 +55,7 @@ def nodeCollectData(pod, container, defaults, taglist, mappingList, boEmoticon):
         for statuses in pod.status.container_statuses:
             log.info("pod-container-name:" + statuses.name)
 
-            if (container.name == statuses.name):
+            if container.name == statuses.name:
                 if statuses.state.running is not None:
                     status = "running"
                     if statuses.state.running.started_at:
@@ -74,7 +74,7 @@ def nodeCollectData(pod, container, defaults, taglist, mappingList, boEmoticon):
 
     if terminated is False and pod.status.conditions is not None:
         for info in pod.status.conditions:
-            if (info.status == 'False'):
+            if info.status == 'False':
                 status = info.reason
                 statusMessage = info.message
 
@@ -212,6 +212,7 @@ def main():
     log.debug(label_selector)
     log.debug(field_selector)
 
+    ret = []
     if field_selector and label_selector:
         ret = v1.list_pod_for_all_namespaces(
             watch=False,
@@ -253,7 +254,7 @@ def main():
                                         )
 
             if running is False:
-                if(node_data["terminated"] is False):
+                if node_data["terminated"] is False:
                     node_set.append(node_data)
 
             if running is True:

--- a/contents/pods-wait.py
+++ b/contents/pods-wait.py
@@ -20,8 +20,9 @@ if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
 
 def wait():
     try:
-        name = environ.get('RD_CONFIG_NAME', environ.get('RD_NODE_DEFAULT_NAME'))
-        namespace = environ.get('RD_CONFIG_NAMESPACE', environ.get('RD_NODE_DEFAULT_NAMESPACE', 'default'))
+        data = common.get_code_node_parameter_dictionary()
+        name = data['name']
+        namespace = data['namespace']
         retries = int(environ.get("RD_CONFIG_RETRIES"))
         sleep = float(environ.get("RD_CONFIG_SLEEP"))
         show_log = environ.get("RD_CONFIG_SHOW_LOG") == "true"
@@ -39,11 +40,11 @@ def wait():
         status = False
 
         if api_response.status.container_statuses:
-           status = api_response.status.container_statuses[0].ready
+            status = api_response.status.container_statuses[0].ready
 
         # Poll for completion if retries
         retries_count = 0
-        while status == False:
+        while not status:
             retries_count = retries_count + 1
             if retries_count > retries:
                 log.error("Number of retries exceeded")
@@ -64,7 +65,8 @@ def wait():
 
         if show_log:
             for i in range(len(api_response.status.container_statuses)):
-                log.info("Fetching logs from pod: {0}    -- container {1} ".format(name,api_response.status.container_statuses[i].name))
+                log.info("Fetching logs from pod: {0}    -- container {1} "
+                         .format(name, api_response.status.container_statuses[i].name))
                 pod_log = core_v1.read_namespaced_pod_log(
                     name=name,
                     namespace=namespace,

--- a/contents/tests/test_common.py
+++ b/contents/tests/test_common.py
@@ -1,0 +1,168 @@
+"""
+Unit tests for common.py functions.
+"""
+
+import json
+import os
+import unittest
+
+from .. import common
+
+
+class TestCommon(unittest.TestCase):
+
+    def test_parse_ports(self):
+        """
+        Test parsePorts function.
+
+        The current code this tests does not create a stub name when a single
+        port is passed instead of a list of ports. It's not clear if that is
+        intentional or accidental, so in that respect this test is only
+        intended to prevent regressions, not to suggest there is a fundamental
+        problem with naming a single port.
+        """
+        entry = {'node_port': 90, 'port': 8080, 'protocol': 'http', 'targetPort': 80}
+        named_entry = {'name': 'foo', 'node_port': 90, 'port': 8080, 'protocol': 'http', "targetPort": 80}
+
+        data = json.dumps(entry)
+        actual = common.parsePorts(data)
+        port = actual.pop()
+        self.assert_port_match(port, entry, None)
+
+        data = json.dumps(named_entry)
+        actual = common.parsePorts(data)
+        port = actual.pop()
+        self.assert_port_match(port, named_entry, None)
+
+        data = json.dumps([named_entry, entry])
+        actual = common.parsePorts(data)
+        port = actual.pop()
+        self.assert_port_match(port, entry, entry['protocol'] + str(entry['port']))
+        port = actual.pop()
+        self.assert_port_match(port, entry, named_entry['name'])
+
+    def assert_port_match(self, port, expected, name):
+        """
+        Asserts that a port object matches the input array.
+
+        :param port:
+        :param expected:
+        :param name:
+        :returns: None
+        """
+        self.assertEqual(port.port, expected['port'])
+        self.assertEqual(port.node_port, expected['node_port'])
+        self.assertEqual(port.protocol, expected['protocol'])
+        self.assertEqual(port.target_port, expected['targetPort'])
+        self.assertEqual(port.name, name)
+
+    def test_get_code_node_parameter_dictionary(self):
+        os.environ.clear()
+        data = common.get_code_node_parameter_dictionary()
+        self.assertIsNone(data['name'])
+        self.assertEqual('default', data['namespace'])
+        self.assertIsNone(data['container_name'])
+        [actual_name, actual_namespace, actual_container] = common.get_core_node_parameter_list()
+        self.assertEqual(data['name'], actual_name)
+        self.assertEqual(data['namespace'], actual_namespace)
+        self.assertEqual(data['container_name'], actual_container)
+
+        name = 'Node'
+        namespace = 'Space'
+        container = 'Container'
+        os.environ.setdefault('RD_NODE_DEFAULT_NAME', name)
+        os.environ.setdefault('RD_NODE_DEFAULT_NAMESPACE', namespace)
+        os.environ.setdefault('RD_NODE_DEFAULT_CONTAINER_NAME', container)
+        self.assert_dictionary_matches(name, namespace, container)
+
+        name = 'Config Node'
+        namespace = 'Config Space'
+        config_container = 'Config Container'
+        os.environ.setdefault('RD_CONFIG_NAME', name)
+        os.environ.setdefault('RD_CONFIG_NAMESPACE', namespace)
+        os.environ.setdefault('RD_CONFIG_CONTAINER_NAME', config_container)
+        self.assert_dictionary_matches(name, namespace, container)
+
+    def assert_dictionary_matches(self, name, namespace, container):
+        """Asserts that a """
+        data = common.get_code_node_parameter_dictionary()
+        self.assertEqual(name, data['name'])
+        self.assertEqual(namespace, data['namespace'])
+        self.assertEqual(container, data['container_name'])
+        [actual_name, actual_namespace, actual_container] = common.get_core_node_parameter_list()
+        self.assertEqual(name, actual_name)
+        self.assertEqual(namespace, actual_namespace)
+        self.assertEqual(container, actual_container)
+
+    def test_create_volume(self):
+        data = {}
+        self.assertIsNone(common.create_volume(data))
+
+        data = {'name': 'volumeName'}
+        self.assertEqual(data['name'], common.create_volume(data).name)
+
+        claim = 'CLAIM'
+        path_name = 'PATH'
+        path_type = 'Directory'
+        data = {
+            'name': 'volumeName',
+            'persistentVolumeClaim': {'claimName': claim},
+            'hostPath': {'path': path_name, 'type': path_type},
+        }
+        volume = common.create_volume(data)
+        pvc = volume.persistent_volume_claim
+        path = volume.host_path
+        self.assertEqual(claim, pvc.claim_name)
+        self.assertEqual(path_name, path.path)
+
+        data['hostPath'] = {'path': path_name}
+        volume = common.create_volume(data)
+        self.assertEqual(claim, volume.persistent_volume_claim.claim_name)
+        # This is strange -- the code is forcing a constraint on path type
+        # that kubernetes itself does not have. I think this assertion should
+        # pass but it does not. I think the indent on line 254 of common.py
+        # is wrong. So I'm going to stop here and ask the maintainer via
+        # a pull request.
+        # self.assertEqual(path_name, path.path)
+
+    def test_create_volume_mount(self):
+        """
+        Tests create_volume_mount() function.
+
+        There is not much happening in this test. We are simply putting in a
+        guardrail against silly typographical errors as code might change in
+        the future.
+
+        :return: None
+        """
+        data = {'name': 'volumeName'}
+        self.assertIsNone(common.create_volume_mount(data))
+
+        data = {'mountPath': 'mountPath'}
+        self.assertIsNone(common.create_volume_mount(data))
+
+        data = {
+            'name': 'volumeName',
+            'mountPath': 'mountPath',
+        }
+        mount = common.create_volume_mount(data)
+        self.assertEqual(data['name'], mount.name)
+        self.assertEqual(data['mountPath'], mount.mount_path)
+        self.assertIsNone(mount.sub_path)
+        self.assertFalse(mount.read_only)
+
+        data = {
+            'name': 'volumeName',
+            'mountPath': 'mountPath',
+            'subPath': 'subPath',
+            'readOnly': True,
+        }
+        mount = common.create_volume_mount(data)
+        self.assertEqual(data['name'], mount.name)
+        self.assertEqual(data['mountPath'], mount.mount_path)
+        self.assertEqual(data['subPath'], mount.sub_path)
+        self.assertTrue(mount.read_only)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add some unit tests for code in common.py
Refactor pods_*.py to share code for reading and logging core configuration info in pods/nodes
Also, in the files edited, fix a bit of whitespace to comply with PIP-8 for empty lines and spaces around "," and "="

This came out of an effort to make parts of the system tested and testable -- by using a shared function for collecting node parameters, we make it testable. In addition, I have started building tests for functions in common.py but it seems like the test for common.create_volume() has surface either a bug or an undocumented additional constraint on volume YAML, so that seemed like a good point to stop and get feedback from the maintainer.

The current code seems to require volume type be specified for a volume, but the API does not require volume type checks. It looks like it might be an incorrect indentation in the python. If it is not a bug, I think it should be documented so it's clear the plugin is more strict than kubernetes itself is.

Since this approach to testing and consolidating code needs agreement from the maintainer anyway, I'm creating this pull request for comment on the work so far.