### PR TITLE
possibly incorrect indents in create_volume() in common.py

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -191,13 +191,11 @@ def create_volume(volume_data):
 
         # hostpath
         if "hostPath" in volume_data and "path" in volume_data["hostPath"]:
-            host_path = client.V1HostPathVolumeSource(
-                path=volume_data["hostPath"]["path"]
-            )
-
-            if "hostPath" in volume_data and "type" in volume_data["hostPath"]:
+            host_path = client.V1HostPathVolumeSource(path=volume_data["hostPath"]["path"])
+            if "type" in volume_data["hostPath"]:
                 host_path.type = volume_data["hostPath"]["type"]
-                volume.host_path = host_path
+            volume.host_path = host_path
+
         # nfs
         if ("nfs" in volume_data and
                 "path" in volume_data["nfs"] and


### PR DESCRIPTION
The indents in the current code do not correspond to the python k8s API and make the code subject to failure if type is not specified in the YAML. But I think the data maps to https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1HostPathVolumeSource.md whihc says type is optional.

On that basis, I think volume.host_paath should be set whether or not a type is specified and the code should not fail if a type is unspecified.