### PR TITLE
Allow to launch a job with a serviceaccount

### DIFF
--- a/contents/job-create.py
+++ b/contents/job-create.py
@@ -110,11 +110,17 @@ def create_job_object(data):
 
         container.env_from = env_from
 
+    serviceaccount = None                                                                                                                                                                                                                     
+    if "serviceaccount" in data:
+      serviceaccount = data["serviceaccount"]
+
+        
     template_spec = client.V1PodSpec(
         containers=[
             container
         ],
-        restart_policy=data["job_restart_policy"])
+        restart_policy=data["job_restart_policy"],
+        service_account_name = serviceaccount)                                                                                                                                                                                                
 
     if "node_selector" in data:
         node_selectors_array = data["node_selector"].split(',')
@@ -212,7 +218,10 @@ def main():
 
     if os.environ.get('RD_CONFIG_PARALLELISM'):
         data["parallelism"] = os.environ.get('RD_CONFIG_PARALLELISM')
-
+        
+    if os.environ.get('RD_CONFIG_SERVICEACCOUNT'):
+        data["serviceaccount"] = os.environ.get('RD_CONFIG_SERVICEACCOUNT')   
+        
     if os.environ.get('RD_CONFIG_LABELS'):
         data["labels"] = os.environ.get('RD_CONFIG_LABELS')
 


### PR DESCRIPTION
In order to limit right access to job, we can use serviceaccount.