### PR TITLE
Ignore non ascii chars that cant be encoded for prints

### DIFF
--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -108,7 +108,7 @@ def wait():
                 for line in w.stream(core_v1.read_namespaced_pod_log,
                                         name=pod_name,
                                         namespace=namespace):
-                    print(line)
+                    print(line.encode('ascii', 'ignore'))
 
                 log.info("=========================== job log end ===========================")
 

--- a/contents/pods-read-logs.py
+++ b/contents/pods-read-logs.py
@@ -37,14 +37,14 @@ def main():
                                      name=data["name"],
                                      namespace=data["namespace"],
                                      follow=False):
-                    print(line)
+                    print(line.encode('ascii', 'ignore'))
             else:
                 w = watch.Watch()
                 for line in w.stream(v1.read_namespaced_pod_log, name=data["name"],
                                      container=data["container"],
                                      namespace=data["namespace"],
                                      follow=False):
-                    print(line)
+                    print(line.encode('ascii', 'ignore'))
         else:
             if data["container"]:
                 ret = v1.read_namespaced_pod_log(


### PR DESCRIPTION
If there is a non ascii char, the plugin breaks with the error below and fails the rundeck job.
this fix will skip the print of the char, but probably most of the log will still be usable and its better than current behaviour.

in my case it was the char µ, but it can happen with other chars too.

```Traceback (most recent call last):
  File "/var/lib/rundeck/libext/cache/kubernetes-plugin-2.0.5-SNAPSHOT/job-wait.py", line 148, in <module>
    main()
  File "/var/lib/rundeck/libext/cache/kubernetes-plugin-2.0.5-SNAPSHOT/job-wait.py", line 144, in main
    wait()
  File "/var/lib/rundeck/libext/cache/kubernetes-plugin-2.0.5-SNAPSHOT/job-wait.py", line 111, in wait
    print(line)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xb5' in position 11568: ordinal not in range(128)
Failed: NonZeroResultCode: Script result code was: 1
Execution failed: 9117 in project xxx: [Workflow result: , step failures: {2=Dispatch failed on 1 nodes: [localhost: NonZeroResultCode: Script result code was: 1 + {dataContext=MultiDataContextImpl(map={}, base=null)} ]}, Node failures: {localhost=[NonZeroResultCode: Script result code was: 1 + {dataContext=MultiDataContextImpl(map={}, base=null)} ]}, status: failed]```