### PR TITLE
Change output to print

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -531,7 +531,7 @@ def run_interactive_command(name, namespace, container, command):
         if resp.peek_stdout():
             print("%s" % resp.read_stdout())
         if resp.peek_stderr():
-            log.error("%s", resp.read_stderr())
+            print(resp.read_stderr())
 
     ERROR_CHANNEL = 3
     err = api.api_client.last_response.read_channel(ERROR_CHANNEL)


### PR DESCRIPTION
fix https://github.com/rundeckpro/rundeckpro/issues/2068

Problem: k8s python library is interpreting verbose command output as an error
Solution: Instead of logging answer as an error it just uses a regular print to show in the job log output

<img width="1327" alt="Screen Shot 2022-02-10 at 11 43 30" src="https://user-images.githubusercontent.com/50217398/153431974-a409e839-3e58-47c9-a6b5-30f6ea47f46d.png">

