### PR TITLE
Fix K8s auth token to read token from storage path

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -45,8 +45,11 @@ def connect():
     url = os.environ.get('RD_CONFIG_URL')
     
     token = os.environ.get('RD_CONFIG_TOKEN')
+
     if not token:
-        token = os.environ.get('RD_CONFIG_TOKEN_STORAGE_PATH')
+      if os.environ.get('RD_CONFIG_TOKEN_STORAGE_PATH'):
+        with open(os.environ.get('RD_CONFIG_TOKEN_STORAGE_PATH'),"r") as f:
+          token = f.read()
 
     log.debug("config file")
     log.debug(config_file)


### PR DESCRIPTION
Assuming RD_CONFIG_TOKEN_STORAGE_PATH is used to store the file path where the token is kept.  Example RD_CONFIG_TOKEN_STORAGE_PATH="/serviceaccount/token",  So we read the file's content instead of the file path. Added fix for the same.