### PR TITLE
Aligned volume_mounts specification for 'Kubernetes-Create-Pod'

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2061,10 +2061,12 @@ providers:
       - name: volume_mounts
         type: String
         title: "Volume Mounts"
-        description: "Volume Mounts, name=mountPath format. Use comma for multiples volume  "
+        description: "Volume Mounts, yaml format (https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/#configure-a-volume-for-a-pod)"
         required: false
         renderingOptions:
           groupName: Container
+          displayType: MULTI_LINE
+          codeSyntaxMode: yaml
       - name: volumes
         type: String
         title: "Volumes"


### PR DESCRIPTION
Simple fix to properly mount volumes on ephemeral pods