### PR TITLE
Added support for freeform pods

### DIFF
--- a/contents/create-from-yaml.py
+++ b/contents/create-from-yaml.py
@@ -29,6 +29,16 @@ def main():
     common.connect()
 
     try:
+        if data["type"] == "Pod":
+            api_instance = client.CoreV1Api()
+            dep = yaml.safe_load(data["yaml"])
+            resp = api_instance.create_namespaced_pod(
+                body=dep,
+                namespace=data["namespace"],
+                pretty="true")
+
+            print(common.parseJson(resp.status))
+
         if data["type"] == "Deployment":
             dep = yaml.safe_load(data["yaml"])
             api_instance = client.AppsV1Api()
@@ -51,8 +61,8 @@ def main():
 
         if data["type"] == "StatefulSet":
             dep = yaml.safe_load(data["yaml"])
-            k8s_beta = client.AppsV1Api()
-            resp = k8s_beta.create_namespaced_stateful_set(
+            api_instance = client.AppsV1Api()
+            resp = api_instance.create_namespaced_stateful_set(
                 body=dep,
                 namespace=data["namespace"],
                 pretty="true")
@@ -71,8 +81,8 @@ def main():
 
         if data["type"] == "Ingress":
             dep = yaml.safe_load(data["yaml"])
-            k8s_beta = client.ExtensionsV1beta1Api()
-            resp = k8s_beta.create_namespaced_ingress(
+            api_instance = client.NetworkingV1Api()
+            resp = api_instance.create_namespaced_ingress(
                 body=dep,
                 namespace=data["namespace"],
                 pretty="true")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2061,10 +2061,12 @@ providers:
       - name: volume_mounts
         type: String
         title: "Volume Mounts"
-        description: "Volume Mounts, name=mountPath format. Use comma for multiples volume  "
+        description: "Volume Mounts, yaml format (https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/#configure-a-volume-for-a-pod)"
         required: false
         renderingOptions:
           groupName: Container
+          displayType: MULTI_LINE
+          codeSyntaxMode: yaml
       - name: volumes
         type: String
         title: "Volumes"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -912,7 +912,7 @@ providers:
         title: "Type"
         description: "Type"
         required: true
-        values: Deployment,StatefulSet,ConfigMap,Service,Ingress,Job,StorageClass,PersistentVolume,PersistentVolumeClaim,Secret
+        values: Pod,Deployment,StatefulSet,ConfigMap,Service,Ingress,Job,StorageClass,PersistentVolume,PersistentVolumeClaim,Secret
       - name: yaml
         type: String
         title: "YAML String"


### PR DESCRIPTION
Needed to be able to spin pods with service accounts on GKE (needed for workload identity), and `stdin:true` and `tty:true` options set. That way I can execute arbitrary scripts into them. :+1: 