### PR TITLE
feat(job-delete, job-wait): Change k8s method in job scripts considering RBAC

### DIFF
--- a/contents/job-delete.py
+++ b/contents/job-delete.py
@@ -34,24 +34,22 @@ def main():
         pretty = 'true'
 
         v1 = client.CoreV1Api()
-        ret = v1.list_pod_for_all_namespaces(
-            watch=False,
+        ret = v1.list_namespaced_pod(
+            namespace=data["namespace"],
             label_selector=label_selector
         )
 
-        print("pods found: %s" % len(ret.items))
+        log.info("pods found: %s" % len(ret.items))
 
         for i in ret.items:
-            print("Removing pod %s" % (i.metadata.name))
-
-        watch = True
+            log.info("Removing pod %s" % i.metadata.name)
 
         try:
             api_response = v1.delete_collection_namespaced_pod(data["namespace"],
                                                                pretty=pretty,
                                                                label_selector=label_selector)
 
-            print(common.parseJson(api_response))
+            log.debug(common.parseJson(api_response))
         except ApiException:
             log.exception("Exception when calling CoreV1Api->delete_collection_namespaced_pod:")
 
@@ -64,8 +62,7 @@ def main():
             body=body,
             pretty=pretty
         )
-
-        print(common.parseJson(api_response.status))
+        log.debug(common.parseJson(api_response.status))
 
     except ApiException:
         log.exception("Exception when calling delete_namespaced_job:")

--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -83,12 +83,12 @@ def wait():
                 for line in w.stream(core_v1.read_namespaced_pod_log,
                                         name=pod_name,
                                         namespace=namespace):
-                    print(line.encode('ascii', 'ignore'))
+                    log.info(line.encode('ascii', 'ignore'))
 
             #check status job
             batch_v1 = client.BatchV1Api()
 
-            api_response = batch_v1.read_namespaced_job_status(
+            api_response = batch_v1.read_namespaced_job(
                 name,
                 namespace,
                 pretty="True"


### PR DESCRIPTION
IMO, when using k8s in the rundeck environment, you probably have limited role. Therefore, you should call k8s API which requires minimal role
* read_namespaced_job_status -> read_namespaced_job

read_namespaced_job_status needs  role `API group "batch", resource "jobs/status", verbs: "get" in its namespace`
read_namespaced_job needs  role `API group "batch", resource "jobs", verbs: "get" in its namespace`

there is no essential difference

* list_pod_for_all_namespaces -> list_namespaced_pod
 
list_pod_for_all_namespaces needs role `API group "", resource "pods", verbs: "list" in cluster scope`
list_namespaced_pod needs role `API group "", resource "pods", verbs: "list" in its namespace`

---

* Change print to use logger
  - I think this repo needs lint rules