### PR TITLE
RSE-250: get pods on authorized namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ This plugin allows getting the container pods from kubernetes as rundeck nodes.
 * **Tags**: List of tags. You can add static and custom tags, for example:
 ```tag.selector=default:image, tag.selector=default:status, kubernetes```
 
+* **Namespace** Retrieve only pods from a desired namespace. (An empty value results in listing pods from all namespaces)
+For example: `default` will result on listing the pods on "default" namespace.
 * **Field Selector**: Filter the list of pods using a response's API fields. For further information check SDK docs [here](https://github.com/kubernetes-client/python/blob/fd5a0c49259e83d928535dd66ab083ddb92ccecf/kubernetes/docs/CoreV1Api.md#return-type-116).
-For example: ```metadata.namespace=default``` will show the pods of the default namespace.
+For example: ```metadata.uid=123``` will show the pod with uid 123.
 * **Just Running Pods?**: Filter by running pods
 
 This plugin generates a list of `default` pod's attributes in order to reference them on the custom config parameters of the plugin (eg: default:status, default:image). The following list are the default available attributes:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -40,7 +40,7 @@ providers:
       - name: namespace_filter
         type: String
         title: "Namespace"
-        description: "Filter pods by namespace."
+        description: "Filter pods by namespace. (Takes all namespaces if not specified)"
         required: false
         default: ''
         renderingOptions:
@@ -50,7 +50,7 @@ providers:
         title: "Field Selector"
         description: "Filter for a field name (check API response fields https://github.com/kubernetes-client/python/blob/fd5a0c49259e83d928535dd66ab083ddb92ccecf/kubernetes/docs/CoreV1Api.md#return-type-116)"
         required: false
-        default: 'metadata.namespace=default'
+        default: ''
         renderingOptions:
           groupName: Config
       - name: label_selector

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -37,6 +37,14 @@ providers:
         default: 'tag.selector=default:status'
         renderingOptions:
           groupName: Config
+      - name: namespace_filter
+        type: String
+        title: "Namespace"
+        description: "Filter pods by namespace."
+        required: false
+        default: ''
+        renderingOptions:
+          groupName: Config
       - name: field_selector
         type: String
         title: "Field Selector"


### PR DESCRIPTION
Ticket: https://pagerduty.atlassian.net/browse/RSE-250

#### Problem
Can not load node sources when using a token for a user that has access to only specific namespaces.

#### Solution
Include a field "Namespace" among the other "Config" fields:
![image](https://user-images.githubusercontent.com/49494423/206287813-e36528b4-7f05-499a-98de-eedc75e4713e.png)

________
These 2 values would be equivalent:
![image](https://user-images.githubusercontent.com/49494423/206288126-a28999ab-8999-4814-aca1-028882a4ddbc.png)

The difference is that using field selector you will get an error if you don't have permissions to access other namespaces, because it will load all pods from any namespace and after that it will apply the selector.