### PR TITLE
RSE-291: Cannot Delete Ingress with Kubernetes Plugin

### DIFF
--- a/contents/delete.py
+++ b/contents/delete.py
@@ -68,9 +68,9 @@ def main():
                 pretty="true")
 
         if data["type"] == "Ingress":
-            apps_v1 = client.ExtensionsV1beta1Api()
+            networkingV1Api = client.NetworkingV1Api()
             body = client.V1DeleteOptions()
-            resp = apps_v1.delete_namespaced_ingress(
+            resp = networkingV1Api.delete_namespaced_ingress(
                 name=data["name"],
                 namespace=data["namespace"],
                 body=body,


### PR DESCRIPTION
# RSE-291: Cannot Delete Ingress with Kubernetes Plugin
Rundeck were unable to delete an ingress with the plugin.

## The Problem
Deprecation of: 'ExtensionsV1beta1Api()'

## The Solution
Usage of ''NetworkingV1Api()"

## See docs:
[Python Client](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/NetworkingV1Api.md#delete_namespaced_ingress)