### PR TITLE
Add "container" property to Execute Command workflow step

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2284,6 +2284,11 @@ providers:
         title: "Pod Name"
         description: "Pod Name"
         required: false
+      - name: container
+        type: String
+        title: "Container Name"
+        description: "Container name within the pod to execute the command on.\n This is only relevant for pods with multiple containers in them."
+        required: false
       - name: namespace
         type: String
         title: "Namespace"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2287,7 +2287,7 @@ providers:
       - name: container
         type: String
         title: "Container Name"
-        description: "Container name within the pod to execute the command on.\n This is only relevant for pods with multiple containers in them."
+        description: "Container name within the pod to execute the command on. This is only relevant for pods with multiple containers in them."
         required: false
       - name: namespace
         type: String

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2287,7 +2287,7 @@ providers:
       - name: container
         type: String
         title: "Container Name"
-        description: "Container name within the pod to execute the command on.\n This is only relevant for pods with multiple containers in them."
+        description: "(Optional) Container name within the pod to execute the command.\n This is only relevant for pods with multiple containers in them. Leave blank to default to the first container in the Pod definition."
         required: false
       - name: namespace
         type: String

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2287,7 +2287,7 @@ providers:
       - name: container
         type: String
         title: "Container Name"
-        description: "Container name within the pod to execute the command on. This is only relevant for pods with multiple containers in them."
+        description: "Container name within the pod to execute the command on.\n This is only relevant for pods with multiple containers in them."
         required: false
       - name: namespace
         type: String


### PR DESCRIPTION
Backend logic already existed to accept the container property, but the property simply hadn't been added to the "Pod / Execute Command" workflow step. 
Unsure why tests are failing.  Plugin works as expected: specifying the container (within the same pod) executes the command in the desired container.

![Screen Shot 2023-01-31 at 5 04 49 PM](https://user-images.githubusercontent.com/11511251/215919936-a1b73d91-8aca-4ed3-8243-e7d1be24fa81.png)