### PR TITLE
RUN-1525: Add plugin for Ephemeral Debug Container

### DIFF
--- a/contents/debug-ephemeral-container.py
+++ b/contents/debug-ephemeral-container.py
@@ -19,8 +19,6 @@ def main():
 
     common.connect()
 
-    print("Container image: " + os.environ.get("RD_CONFIG_CONTAINER_IMAGE"))
-    print("Container name: " + os.environ.get("RD_CONFIG_CONTAINER_NAME"))
     container_name = os.environ.get("RD_CONFIG_CONTAINER_NAME")
     container_image = os.environ.get("RD_CONFIG_CONTAINER_IMAGE")
 

--- a/contents/debug-ephemeral-container.py
+++ b/contents/debug-ephemeral-container.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python -u
+import logging
+import sys
+import os
+import common
+
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+from kubernetes import watch
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO,
+                    format='%(message)s')
+log = logging.getLogger('kubernetes-model-source')
+
+if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
+    log.setLevel(logging.DEBUG)
+
+def main():
+
+    common.connect()
+
+    try:
+        v1 = client.CoreV1Api()
+
+        [name, namespace, container] = common.get_core_node_parameter_list()
+
+        if not container:
+            core_v1 = client.CoreV1Api()
+            response = core_v1.read_namespaced_pod_status(
+                name=name,
+                namespace=namespace,
+                pretty="True"
+            )
+            container = response.spec.containers[0].name
+
+        common.log_pod_parameters(log, {'name': name, 'namespace': namespace, 'container_name': container})
+        common.verify_pod_exists(name, namespace)
+
+        # add a debug container to it
+        spec = client.models.V1EphemeralContainer(
+            name="debugger",
+            image = "centos:7",
+            stdin=True,
+            tty=True)
+        body = {
+            "spec": {
+                "ephemeralContainers": [
+                    spec.to_dict()
+                ]
+            }
+        }
+        response = v1.patch_namespaced_pod_ephemeralcontainers(
+            name,
+            namespace,
+            body,
+            _preload_content=False)
+
+        print(response.data)
+#         print("Read(): " + response.read())
+
+
+    except ApiException:
+        log.exception("Exception error creating:")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/contents/debug-ephemeral-container.py
+++ b/contents/debug-ephemeral-container.py
@@ -68,8 +68,7 @@ def main():
             body,
             _preload_content=False)
 
-        print(response.data)
-
+        print("Ephemeral container " + container_name + " successfully added to pod " + name)
 
     except ApiException:
         log.exception("Exception error creating:")

--- a/contents/debug-ephemeral-container.py
+++ b/contents/debug-ephemeral-container.py
@@ -19,6 +19,11 @@ def main():
 
     common.connect()
 
+    print("Container image: " + os.environ.get("RD_CONFIG_CONTAINER_IMAGE"))
+    print("Container name: " + os.environ.get("RD_CONFIG_CONTAINER_NAME"))
+    container_name = os.environ.get("RD_CONFIG_CONTAINER_NAME")
+    container_image = os.environ.get("RD_CONFIG_CONTAINER_IMAGE")
+
     try:
         v1 = client.CoreV1Api()
 
@@ -38,8 +43,8 @@ def main():
 
         # add a debug container to it
         spec = client.models.V1EphemeralContainer(
-            name="debugger",
-            image = "centos:7",
+            name = container_name,
+            image = container_image,
             stdin=True,
             tty=True)
         body = {

--- a/contents/debug-ephemeral-container.py
+++ b/contents/debug-ephemeral-container.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import os
 import common
+import json
 
 from kubernetes import client
 from kubernetes.client.rest import ApiException
@@ -68,7 +69,11 @@ def main():
             body,
             _preload_content=False)
 
-        print("Ephemeral container " + container_name + " successfully added to pod " + name)
+        if os.environ.get("RD_CONFIG_PRINT_POD_SPEC") == "true":
+            json_data = json.loads(response.data.decode("utf-8"))
+            print(json.dumps(json_data, indent=2))
+        else:
+            print("Ephemeral container " + container_name + " successfully added to pod " + name)
 
     except ApiException:
         log.exception("Exception error creating:")

--- a/contents/debug-ephemeral-container.py
+++ b/contents/debug-ephemeral-container.py
@@ -52,12 +52,7 @@ def main():
                         "image": container_image,
                         "targetContainerName": target_container,
                         "stdin": True,
-                        "tty": True,
-#                         "volumeMounts": [{
-#                             "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
-#                             "name": "kube-api-access-qnhvv",
-#                             "readOnly": true
-#                         }]
+                        "tty": True
                     }
                 ]
             }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2348,6 +2348,36 @@ providers:
         scope: Instance
         renderingOptions:
           groupName: Authentication
+  - name: Kubernetes-Ephemeral-Container
+    service: WorkflowNodeStep
+    title: Kubernetes / Pods / Debug Ephemeral Container
+    description: 'Add an ephemeral container to a pod for debugging.'
+    plugin-type: script
+    script-interpreter: python -u
+    script-file: debug-ephemeral-container.py
+    script-args: ${config.name}
+    config:
+      - name: name
+        type: String
+        title: "Pod Name"
+        required: true
+        description: "Name of the running pod that the ephemeral container will get attached to."
+      - name: namespace
+        type: String
+        title: "Namespace"
+        description: "Namespace where the job was created"
+        required: false
+        default: default
+      - name: container-name
+        type: String
+        title: "Name for Ephemeral Container"
+        description: "Name for the ephemeral container that will be added to the running pod."
+        required: false
+      - name: image
+        type: String
+        title: "Container Image"
+        description: "Image for the ephemeral container to be added to the running pod."
+        default: "busybox"
   - name: Kubernetes-InlineScript-Step
     service: WorkflowNodeStep
     title: Kubernetes / Pods / Execute Script

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2379,6 +2379,11 @@ providers:
         title: "Container Image"
         description: "Image for the ephemeral container to be added to the running pod."
         default: "busybox"
+      - name: target_container
+        type: String
+        title: "Target Container"
+        description: "Name of a container within the running pod that the ephemeral container should target.\n The ephemeral container will be run in the namespaces (IPC, PID, etc) of the Target Container. If not set then the ephemeral container uses the namespaces configured in the Pod spec."
+        required: false
   - name: Kubernetes-InlineScript-Step
     service: WorkflowNodeStep
     title: Kubernetes / Pods / Execute Script

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2384,6 +2384,49 @@ providers:
         title: "Target Container"
         description: "Name of a container within the running pod that the ephemeral container should target.\n The ephemeral container will be run in the namespaces (IPC, PID, etc) of the Target Container. If not set then the ephemeral container uses the namespaces configured in the Pod spec."
         required: false
+      - name: config_file
+        type: String
+        title: "Kubernetes Config File Path"
+        description: "Leave empty if you want to pass the connection parameters"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Authentication
+      - name: url
+        type: String
+        title: "Cluster URL"
+        description: "Kubernetes Cluster URL"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Authentication
+      - name: token
+        type: String
+        title: "Token"
+        required: false
+        scope: Instance
+        description: "Kubernetes API Token"
+        renderingOptions:
+          groupName: Authentication
+          selectionAccessor: "STORAGE_PATH"
+          valueConversion: "STORAGE_PATH_AUTOMATIC_READ"
+          storage-path-root: "keys"
+      - name: verify_ssl
+        type: Boolean
+        title: "Verify ssl"
+        description: "Verify ssl for SSL connections"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Authentication
+      - name: ssl_ca_cert
+        type: String
+        title: "SSL Certificate Path"
+        description: "SSL Certificate Path for SSL connections"
+        required: false
+        scope: Instance
+        renderingOptions:
+          groupName: Authentication
   - name: Kubernetes-InlineScript-Step
     service: WorkflowNodeStep
     title: Kubernetes / Pods / Execute Script

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2368,12 +2368,13 @@ providers:
         description: "Namespace where the job was created"
         required: false
         default: default
-      - name: container-name
+      - name: container_name
         type: String
         title: "Name for Ephemeral Container"
         description: "Name for the ephemeral container that will be added to the running pod."
-        required: false
-      - name: image
+        required: true
+        default: debugger
+      - name: container_image
         type: String
         title: "Container Image"
         description: "Image for the ephemeral container to be added to the running pod."

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2350,7 +2350,7 @@ providers:
           groupName: Authentication
   - name: Kubernetes-Ephemeral-Container
     service: WorkflowNodeStep
-    title: Kubernetes / Pods / Debug Ephemeral Container
+    title: Kubernetes / Pods / Add Ephemeral Debug Container
     description: 'Add an ephemeral container to a pod for debugging.'
     plugin-type: script
     script-interpreter: python -u
@@ -2382,7 +2382,7 @@ providers:
       - name: target_container
         type: String
         title: "Target Container"
-        description: "Name of a container within the running pod that the ephemeral container should target.\n The ephemeral container will be run in the namespaces (IPC, PID, etc) of the Target Container. If not set then the ephemeral container uses the namespaces configured in the Pod spec."
+        description: "Name of a container within the running pod that the ephemeral container should target.\n The ephemeral container will be run in the namespaces (IPC, PID, etc) of the Target Container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. See the official Kubernetes documentation [here](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container) for further details."
         required: false
       - name: print_pod_spec
         type: Boolean

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2384,6 +2384,11 @@ providers:
         title: "Target Container"
         description: "Name of a container within the running pod that the ephemeral container should target.\n The ephemeral container will be run in the namespaces (IPC, PID, etc) of the Target Container. If not set then the ephemeral container uses the namespaces configured in the Pod spec."
         required: false
+      - name: print_pod_spec
+        type: Boolean
+        title: "Print Pod Spec"
+        description: "Optionally print the pod spec to the log output after the ephemeral container has been added."
+        default: "false"
       - name: config_file
         type: String
         title: "Kubernetes Config File Path"

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -2350,7 +2350,7 @@ providers:
           groupName: Authentication
   - name: Kubernetes-Ephemeral-Container
     service: WorkflowNodeStep
-    title: Kubernetes / Pods / Add Ephemeral Debug Container
+    title: Kubernetes / Debug / Ephemeral Container
     description: 'Add an ephemeral container to a pod for debugging.'
     plugin-type: script
     script-interpreter: python -u


### PR DESCRIPTION
Please conduct a code-review of the plugin.  This plugin adds an ephemeral container to an existing (running) pod so that debugging utilities can be used to investigate the other containers in that pod.  
Documentation for this feature can be found [here](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container).