### PR TITLE
Add function to handle Rundeck environment variables and options for execution in pod

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -594,13 +594,14 @@ def handle_rundeck_environment_variables(name, namespace, container):
 
             try:
                 log.debug("coping script from %s to %s", source_file, full_path)
-                copy_file(name,
-                          namespace,
-                          container,
-                          source_file,
-                          destination_path,
-                          destination_file_name
-                          )
+                copy_file(
+                    name=name,
+                    namespace=namespace,
+                    container=container,
+                    source_file=source_file,
+                    destination_path=destination_path,
+                    destination_file_name=destination_file_name
+                )
             
             finally:
                 rundeck_variables[file_key] = full_path
@@ -618,11 +619,12 @@ def clean_up_temporary_files(name, namespace, container, files):
     rm_command = ["rm"] + files
 
     log.debug("removing file %s", rm_command)
-    resp = run_command(name=name,
-                              namespace=namespace,
-                              container=container,
-                              command=rm_command
-                              )
+    resp = run_command(
+               name=name,
+               namespace=namespace,
+               container=container,
+               command=rm_command
+           )
     
     if resp.peek_stdout():
         log.debug(resp.read_stdout())

--- a/contents/pods-node-executor.py
+++ b/contents/pods-node-executor.py
@@ -57,12 +57,12 @@ def main():
         sys.exit(1)
 
     if len(temporary_files) > 0:
-    common.clean_up_temporary_files(
-        name=name,
-        namespace=namespace,
-        container=container,
-        files=temporary_files
-    )
+        common.clean_up_temporary_files(
+            name=name,
+            namespace=namespace,
+            container=container,
+            files=temporary_files
+        )
 
 
 if __name__ == '__main__':

--- a/contents/pods-node-executor.py
+++ b/contents/pods-node-executor.py
@@ -41,10 +41,11 @@ def main():
 
     log.debug("Command: %s ", command)
 
-    environments_variables, temporary_files = common.handle_rundeck_environment_variables(name,
-                                                                                          namespace,
-                                                                                          container
-                                                                                          )
+    environments_variables, temporary_files = common.handle_rundeck_environment_variables(
+                                                  name=name,
+                                                  namespace=namespace,
+                                                  container=container
+                                              )
 
     exec_command = environments_variables + [shell, '-c', command]
 
@@ -56,11 +57,12 @@ def main():
         sys.exit(1)
 
     if len(temporary_files) > 0:
-    common.clean_up_temporary_files(name=name,
-                                    namespace=namespace,
-                                    container=container,
-                                    files=temporary_files
-                                    )
+    common.clean_up_temporary_files(
+        name=name,
+        namespace=namespace,
+        container=container,
+        files=temporary_files
+    )
 
 
 if __name__ == '__main__':

--- a/contents/pods-node-executor.py
+++ b/contents/pods-node-executor.py
@@ -41,17 +41,26 @@ def main():
 
     log.debug("Command: %s ", command)
 
-    # calling exec and wait for response.
-    exec_command = [
-        shell,
-        '-c',
-        command]
+    environments_variables, temporary_files = common.handle_rundeck_environment_variables(name,
+                                                                                          namespace,
+                                                                                          container
+                                                                                          )
 
+    exec_command = environments_variables + [shell, '-c', command]
+
+    # calling exec and wait for response.
     resp, error = common.run_interactive_command(name, namespace, container, exec_command)
 
     if error:
         log.error("error running script")
         sys.exit(1)
+
+    if len(temporary_files) > 0:
+    common.clean_up_temporary_files(name=name,
+                                    namespace=namespace,
+                                    container=container,
+                                    files=temporary_files
+                                    )
 
 
 if __name__ == '__main__':

--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -118,8 +118,13 @@ def main():
         print(resp.read_stderr())
         sys.exit(1)
 
+    environments_variables, temporary_files = common.handle_rundeck_environment_variables(name,
+                                                                                          namespace,
+                                                                                          container
+                                                                                          )
+
     # calling exec and wait for response.
-    exec_command = invocation.split(" ")
+    exec_command = environments_variables + invocation.split(" ")
     exec_command.append(full_path)
 
     if 'RD_CONFIG_ARGUMENTS' in os.environ:
@@ -143,21 +148,12 @@ def main():
             log.info("POD deleted")
         sys.exit(1)
 
-    rm_command = ["rm", full_path]
-
-    log.debug("removing file %s", rm_command)
-    resp = common.run_command(name=name,
-                              namespace=namespace,
-                              container=container,
-                              command=rm_command
-                              )
-
-    if resp.peek_stdout():
-        log.debug(resp.read_stdout())
-
-    if resp.peek_stderr():
-        log.debug(resp.read_stderr())
-        sys.exit(1)
+    temporary_files.append(full_path)
+    common.clean_up_temporary_files(name=name,
+                                    namespace=namespace,
+                                    container=container,
+                                    files=temporary_files
+                                    )
 
 
 if __name__ == '__main__':

--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -118,10 +118,11 @@ def main():
         print(resp.read_stderr())
         sys.exit(1)
 
-    environments_variables, temporary_files = common.handle_rundeck_environment_variables(name,
-                                                                                          namespace,
-                                                                                          container
-                                                                                          )
+    environments_variables, temporary_files = common.handle_rundeck_environment_variables(
+                                                  name=name,
+                                                  namespace=namespace,
+                                                  container=container
+                                              )
 
     # calling exec and wait for response.
     exec_command = environments_variables + invocation.split(" ")
@@ -149,11 +150,12 @@ def main():
         sys.exit(1)
 
     temporary_files.append(full_path)
-    common.clean_up_temporary_files(name=name,
-                                    namespace=namespace,
-                                    container=container,
-                                    files=temporary_files
-                                    )
+    common.clean_up_temporary_files(
+        name=name,
+        namespace=namespace,
+        container=container,
+        files=temporary_files
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I like to improve the script and command execution in pods in the way, that the environment variables set by Rundeck like the possible options of a job, are propagated to the pod. And create with this a behavior like running jobs on the local machine. For this, I wrote two functions.

- `common.handle_rundeck_environment_variables`: This function is called in `pods-run-script.py` and `pods-node-executor.py`. In the function all environment variables of the current Rundeck process are filtered for just variables where the key starts with `RD_`. Also the function looks for variables that starts with `RD_FILE_` that are uploaded files. This files are needed to uploaded to the pod too. The default directory is `/tmp` or what in `RD_NODE_FILE_COPY_DESTINATION_DIR` is defined.
The function returns two arrays. The first array including all environment variables and can be added in front of the execution command. The first element is the command `env` and the following elements in the array are strings in the format `'key=value'`. The second array contains all paths of uploaded files. This array can be used for my second function.

- `common.clean_up_temporary_files`: This function is called in the end of `pods-run-script.py` and `pods-node-executor.py`. Like the name says the function delete uploaded files from the pod.
In the  pods-run-script function the temporary created script is added to the list of to deleting files.

My Background:
I like to use Rundeck in a kind “as a service” for multiple departments in my organization. To separate the environment of every department I like to use pods in my k8s. With this separation the departments can’t break or delete setups from other departments. But to use pods like running jobs on the local Rundeck machine it is needed to also have all Rundeck environment variables and uploaded files inside the pod.