### PR TITLE
Update deprecated gradle setups and remove unsupported Python 2.x test

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,23 +8,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Get Fetch Tags
         run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
         if: "!contains(github.ref, 'refs/tags')"
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'corretto'
+          java-version: 8
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo VERSION=$VERSION >> $GITHUB_OUTPUT
       - name: Upload artifact zip
         uses: actions/upload-artifact@v1.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'corretto'
+          java-version: 8
       - name: Build with Gradle
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo VERSION=$VERSION >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x' ]
+        python-version: [ '3.x' ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Other pull requests are failing because Python 2.x is no longer natively supported on GitHub with Ubuntu-latest.

Also, the gradle test step is headed for trouble due to several deprecations:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-java@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default
> 
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This patch removes the Python 2.x build. Github no longer supports and 2.x version of python, we would need to build our own docker image or use a contributed image of potentially unknown quality to retain that testing.

This patch also upgrades the setup-checkout and setup-java to the current versions. This requires choosing a Java version. I had no real basis for what I should choose, I used corretto...but not for any particular reason.

The gradle/java changes also apply to releasing, and have been added there.