### PR TITLE
[RUN-4725] fix: command arguments need to be split

### DIFF
--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -124,7 +124,8 @@ def main():
 
     if 'RD_CONFIG_ARGUMENTS' in os.environ:
         arguments = os.environ.get('RD_CONFIG_ARGUMENTS')
-        exec_command.append(arguments)
+        for arg in arguments.split(" "):
+            exec_command.append(arg)
 
     log.debug("running script %s", exec_command)
 


### PR DESCRIPTION
Command arguments need to be split when invoking inline scripts in pods.

**Fixes:** passing multiple arguments to inline scripts run via `Kubernetes-InlineScript-Step`.

Previously, the entire `Arguments` field value was appended as a single string element to the exec command, so a script invoked with e.g. `arg1 arg2 arg3` in `Arguments` would receive it all as `$1` (with `$2`, `$3`, ... empty). This change splits `Arguments` on spaces before appending, so each token becomes its own positional argument (`$1`, `$2`, `$3`, ...) — consistent with how the `invocation` field is already handled (line 122).