### PR TITLE
All special characters in jobs/pods logs

### DIFF
--- a/contents/job-wait.py
+++ b/contents/job-wait.py
@@ -83,7 +83,10 @@ def wait():
                 for line in w.stream(core_v1.read_namespaced_pod_log,
                                         name=pod_name,
                                         namespace=namespace):
-                    log.info(line.encode('ascii', 'ignore'))
+                    try:
+                        log.info(line)
+                    except:
+                        log.info(line.encode('ascii', 'ignore'))
 
             #check status job
             batch_v1 = client.BatchV1Api()

--- a/contents/pods-read-logs.py
+++ b/contents/pods-read-logs.py
@@ -35,7 +35,10 @@ def main():
                                      name=data["name"],
                                      tail_lines=os.environ.get('RD_CONFIG_NUMBER_OF_LINES'),
                                      follow=False):
-                    print(line.encode('ascii', 'ignore'))
+                    try:
+                        log.info(line)
+                    except:
+                        log.info(line.encode('ascii', 'ignore'))
             else:
                 w = watch.Watch()
                 for line in w.stream(v1.read_namespaced_pod_log,
@@ -44,7 +47,10 @@ def main():
                                      name=data["name"],
                                      tail_lines=os.environ.get('RD_CONFIG_NUMBER_OF_LINES'),
                                      follow=False):
-                    print(line.encode('ascii', 'ignore'))
+                    try:
+                        log.info(line)
+                    except:
+                        log.info(line.encode('ascii', 'ignore'))
         else:
             if data["container_name"]:
                 ret = v1.read_namespaced_pod_log(


### PR DESCRIPTION
Hi,

I have an issue with special characters disappearing from Kubernetes logs.

I noticed issue #122, which removes all non-ASCII characters, but this also filters out characters like é, è, à, etc., which causes my French messages to be truncated.

I would like to replace:

```python
log.info(line.encode('ascii', 'ignore'))
```

with:

```python
try:
    log.info(line)
except:
    log.info(line.encode('ascii', 'ignore'))
```

I added the try/except as a fallback, but I believe it may not be necessary since log.info(line) already works fine.

Would this change be acceptable?

Here are some screenshots

logs output :
![all-chars](https://github.com/user-attachments/assets/c30f0cc2-e865-441a-9fa2-7d5ed2fe7c38)


Job :
![job](https://github.com/user-attachments/assets/9d600269-852f-4551-ad94-ae211258bc75)

Wait-for :
![wait-for](https://github.com/user-attachments/assets/4865f1e2-172c-48f1-ad29-a95495b13026)

Characters used : ✅ ! \# $ % & ' ( )éèàùüêûîô * + , - . / ; < = > ? @ [ \ ] ^ _ ` { | } ~µ🧙‍

Thanks!