### PR TITLE
Update dependencies of build job

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Get Fetch Tags
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
       - name: Upload artifact zip
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4.0.0
         with:
           # Artifact name
           name: kubernetes-${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
bump checkout and upload-artifact versions to v4