### PR TITLE
Remove unused pprint import in pods-resource-model.py

### DIFF
--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -5,7 +5,6 @@ import os
 import common
 import json
 import shlex
-import pprint
 
 from kubernetes import client
 


### PR DESCRIPTION
The pprint import is unused. It can be removed.