### PR TITLE
ensure copying large files does not cause memory exhaustion

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -22,8 +22,6 @@ logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
 log = logging.getLogger('kubernetes-plugin')
 
-PY = sys.version_info[0]
-
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log.setLevel(logging.DEBUG)
 
@@ -465,8 +463,7 @@ def copy_file(name, namespace, container, source_file, destination_path, destina
             tar.add(name=source_file, arcname=destination_path + "/" + destination_file_name)
 
         tar_buffer.seek(0)
-        commands = []
-        commands.append(tar_buffer.read())
+        sent = False
 
         while resp.is_open():
             resp.update(timeout=1)
@@ -476,13 +473,12 @@ def copy_file(name, namespace, container, source_file, destination_path, destina
                     log.info("%s", resp.read_stdout())
             if resp.peek_stderr():
                 log.error("ERROR: %s", resp.read_stderr())
-            if commands:
-                c = commands.pop(0)
-
-                # Python 3 expects bytes string to transfer the data.
-                if PY == 3:
-                    c = c.decode()
-                resp.write_stdin(c)
+            if not sent:
+                chunk = tar_buffer.read(4096)
+                while chunk:
+                    resp.write_stdin(chunk.decode())
+                    chunk = tar_buffer.read(4096)
+                sent = True
             else:
                 break
         resp.close()


### PR DESCRIPTION
tar_buffer.read() loads the full tar archive into memory. For large files this could be significant. Streaming chunks in a loop reduces peak memory usage.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>