### PR TITLE
[RUN-4727] Token fix for kubernetes Python client >= 35.0.0

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import os
 import tarfile
-from tempfile import TemporaryFile
+import tempfile
 
 import yaml
 import datetime
@@ -89,7 +89,11 @@ def connect():
 
     if config_file:
         log.debug("getting settings from file %s", config_file)
-        config.load_kube_config(config_file=config_file)
+        try:
+            config.load_kube_config(config_file=config_file)
+        except Exception as e:
+            log.error("Failed to load kube config from %s: %s", config_file, e)
+            raise
     else:
         if url and token:
             log.debug("getting settings from plugin configuration")
@@ -125,10 +129,23 @@ def connect():
             if ssl_ca_cert:
                 kubeconfig_dict['clusters'][0]['cluster']['certificate-authority'] = ssl_ca_cert
 
-            config.load_kube_config(config_dict=kubeconfig_dict)
+            kubeconfig_tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
+            yaml.dump(kubeconfig_dict, kubeconfig_tmp)
+            kubeconfig_tmp.close()
+            try:
+                config.load_kube_config(config_file=kubeconfig_tmp.name)
+            except Exception as e:
+                log.error("Failed to configure Kubernetes client with URL=%s: %s", url, e)
+                raise
+            finally:
+                os.unlink(kubeconfig_tmp.name)
         else:
             log.debug("Either URL or Token is not defined. Fall back to getting settings from default config file [$home/.kube/config]")
-            config.load_kube_config()
+            try:
+                config.load_kube_config()
+            except Exception as e:
+                log.error("Failed to load default kube config: %s", e)
+                raise
 
 
 def load_liveness_readiness_probe(data):
@@ -511,7 +528,7 @@ def copy_file(name, namespace, container, source_file, destination_path, destina
                   stdout=False, tty=False,
                   _preload_content=False)
 
-    with TemporaryFile() as tar_buffer:
+    with tempfile.TemporaryFile() as tar_buffer:
         with tarfile.open(fileobj=tar_buffer, mode='w') as tar:
             tar.add(name=source_file, arcname=destination_path + "/" + destination_file_name)
 

--- a/contents/common.py
+++ b/contents/common.py
@@ -129,16 +129,11 @@ def connect():
             if ssl_ca_cert:
                 kubeconfig_dict['clusters'][0]['cluster']['certificate-authority'] = ssl_ca_cert
 
-            kubeconfig_tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False)
-            yaml.dump(kubeconfig_dict, kubeconfig_tmp)
-            kubeconfig_tmp.close()
             try:
-                config.load_kube_config(config_file=kubeconfig_tmp.name)
+                config.load_kube_config_from_dict(kubeconfig_dict, persist_config=False)
             except Exception as e:
                 log.error("Failed to configure Kubernetes client with URL=%s: %s", url, e)
                 raise
-            finally:
-                os.unlink(kubeconfig_tmp.name)
         else:
             log.debug("Either URL or Token is not defined. Fall back to getting settings from default config file [$home/.kube/config]")
             try:

--- a/contents/common.py
+++ b/contents/common.py
@@ -9,7 +9,7 @@ import yaml
 import datetime
 
 from kubernetes import client, config
-from kubernetes.client import Configuration
+
 from kubernetes.stream import stream
 from kubernetes.client.api import core_v1_api
 from kubernetes.client.rest import ApiException
@@ -94,22 +94,38 @@ def connect():
         if url and token:
             log.debug("getting settings from plugin configuration")
 
-            configuration = Configuration()
-            configuration.host = url
+            kubeconfig_dict = {
+                'clusters': [{
+                    'cluster': {
+                        'server': url,
+                    },
+                    'name': 'rundeck-cluster',
+                }],
+                'contexts': [{
+                    'context': {
+                        'cluster': 'rundeck-cluster',
+                        'user': 'rundeck-user',
+                    },
+                    'name': 'rundeck-context',
+                }],
+                'current-context': 'rundeck-context',
+                'users': [{
+                    'user': {
+                        'token': token,
+                    },
+                    'name': 'rundeck-user',
+                }],
+            }
 
             if verify_ssl == 'true':
-                configuration.verify_ssl = verify_ssl
+                kubeconfig_dict['clusters'][0]['cluster']['insecure-skip-tls-verify'] = False
             else:
-                configuration.verify_ssl = None
-                configuration.assert_hostname = False
+                kubeconfig_dict['clusters'][0]['cluster']['insecure-skip-tls-verify'] = True
 
             if ssl_ca_cert:
-                configuration.ssl_ca_cert = ssl_ca_cert
+                kubeconfig_dict['clusters'][0]['cluster']['certificate-authority'] = ssl_ca_cert
 
-            configuration.api_key['authorization'] = token
-            configuration.api_key_prefix['authorization'] = 'Bearer'
-
-            client.Configuration.set_default(configuration)
+            config.load_kube_config(config_dict=kubeconfig_dict)
         else:
             log.debug("Either URL or Token is not defined. Fall back to getting settings from default config file [$home/.kube/config]")
             config.load_kube_config()

--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -7,6 +7,7 @@ import json
 import shlex
 
 from kubernetes import client
+from kubernetes.client.rest import ApiException
 
 
 logging.basicConfig(stream=sys.stderr,
@@ -208,7 +209,13 @@ def main():
 
     node_set = []
 
-    ret = collect_pods_from_api(namespace_filter, label_selector, field_selector)
+    try:
+        ret = collect_pods_from_api(namespace_filter, label_selector, field_selector)
+    except ApiException as e:
+        log.error("Kubernetes API error (HTTP %s): %s", e.status, e.reason)
+        if e.body:
+            log.error("Response body: %s", e.body)
+        sys.exit(1)
 
     for i in ret.items:
         for container in i.spec.containers:

--- a/contents/tests/test_common.py
+++ b/contents/tests/test_common.py
@@ -395,19 +395,20 @@ class TestCommon(unittest.TestCase):
         common.connect()
         mock_config.load_kube_config.assert_called_once_with(config_file='/node/config')
 
+    @patch('contents.common.os.unlink')
     @patch('contents.common.config')
-    def test_connect_url_and_token(self, mock_config):
+    @patch('contents.common.tempfile.NamedTemporaryFile')
+    def test_connect_url_and_token(self, mock_tempfile, mock_config, mock_unlink):
         os.environ.clear()
         os.environ['RD_CONFIG_URL'] = 'https://k8s.example.com'
         os.environ['RD_CONFIG_TOKEN'] = 'my-token'
         os.environ['RD_CONFIG_VERIFY_SSL'] = 'true'
+        mock_file = MagicMock()
+        mock_file.name = '/tmp/kubeconfig.yaml'
+        mock_tempfile.return_value = mock_file
         common.connect()
-        mock_config.load_kube_config.assert_called_once()
-        call_kwargs = mock_config.load_kube_config.call_args
-        config_dict = call_kwargs.kwargs.get('config_dict') or call_kwargs[1].get('config_dict')
-        self.assertEqual(config_dict['clusters'][0]['cluster']['server'], 'https://k8s.example.com')
-        self.assertEqual(config_dict['users'][0]['user']['token'], 'my-token')
-        self.assertFalse(config_dict['clusters'][0]['cluster']['insecure-skip-tls-verify'])
+        mock_config.load_kube_config.assert_called_once_with(config_file='/tmp/kubeconfig.yaml')
+        mock_unlink.assert_called_once_with('/tmp/kubeconfig.yaml')
 
     @patch('contents.common.config')
     def test_connect_default_fallback(self, mock_config):

--- a/contents/tests/test_common.py
+++ b/contents/tests/test_common.py
@@ -395,15 +395,19 @@ class TestCommon(unittest.TestCase):
         common.connect()
         mock_config.load_kube_config.assert_called_once_with(config_file='/node/config')
 
-    @patch('contents.common.client.Configuration.set_default')
     @patch('contents.common.config')
-    def test_connect_url_and_token(self, mock_config, mock_set_default):
+    def test_connect_url_and_token(self, mock_config):
         os.environ.clear()
         os.environ['RD_CONFIG_URL'] = 'https://k8s.example.com'
         os.environ['RD_CONFIG_TOKEN'] = 'my-token'
         os.environ['RD_CONFIG_VERIFY_SSL'] = 'true'
         common.connect()
-        mock_set_default.assert_called_once()
+        mock_config.load_kube_config.assert_called_once()
+        call_kwargs = mock_config.load_kube_config.call_args
+        config_dict = call_kwargs.kwargs.get('config_dict') or call_kwargs[1].get('config_dict')
+        self.assertEqual(config_dict['clusters'][0]['cluster']['server'], 'https://k8s.example.com')
+        self.assertEqual(config_dict['users'][0]['user']['token'], 'my-token')
+        self.assertFalse(config_dict['clusters'][0]['cluster']['insecure-skip-tls-verify'])
 
     @patch('contents.common.config')
     def test_connect_default_fallback(self, mock_config):

--- a/contents/tests/test_common.py
+++ b/contents/tests/test_common.py
@@ -395,20 +395,20 @@ class TestCommon(unittest.TestCase):
         common.connect()
         mock_config.load_kube_config.assert_called_once_with(config_file='/node/config')
 
-    @patch('contents.common.os.unlink')
     @patch('contents.common.config')
-    @patch('contents.common.tempfile.NamedTemporaryFile')
-    def test_connect_url_and_token(self, mock_tempfile, mock_config, mock_unlink):
+    def test_connect_url_and_token(self, mock_config):
         os.environ.clear()
         os.environ['RD_CONFIG_URL'] = 'https://k8s.example.com'
         os.environ['RD_CONFIG_TOKEN'] = 'my-token'
         os.environ['RD_CONFIG_VERIFY_SSL'] = 'true'
-        mock_file = MagicMock()
-        mock_file.name = '/tmp/kubeconfig.yaml'
-        mock_tempfile.return_value = mock_file
         common.connect()
-        mock_config.load_kube_config.assert_called_once_with(config_file='/tmp/kubeconfig.yaml')
-        mock_unlink.assert_called_once_with('/tmp/kubeconfig.yaml')
+        mock_config.load_kube_config_from_dict.assert_called_once()
+        kubeconfig_dict, kwargs = mock_config.load_kube_config_from_dict.call_args
+        self.assertEqual(kwargs.get('persist_config'), False)
+        cluster = kubeconfig_dict[0]['clusters'][0]['cluster']
+        self.assertEqual(cluster['server'], 'https://k8s.example.com')
+        self.assertEqual(cluster['insecure-skip-tls-verify'], False)
+        self.assertEqual(kubeconfig_dict[0]['users'][0]['user']['token'], 'my-token')
 
     @patch('contents.common.config')
     def test_connect_default_fallback(self, mock_config):

--- a/contents/tests/test_pods_resource_model.py
+++ b/contents/tests/test_pods_resource_model.py
@@ -9,6 +9,8 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+from kubernetes.client.rest import ApiException
+
 
 # pods-resource-model.py has a hyphenated name, so use importlib
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -419,6 +421,26 @@ class TestMain(unittest.TestCase):
         import json
         output = mock_print.call_args[0][0]
         self.assertEqual([], json.loads(output))
+
+    @patch.object(pods_resource_model, 'collect_pods_from_api')
+    @patch.object(pods_resource_model.common, 'connect')
+    def test_main_logs_and_exits_on_api_exception(self, mock_connect, mock_collect):
+        os.environ['RD_CONFIG_TAGS'] = 'kubernetes'
+        os.environ['RD_CONFIG_ATTRIBUTES'] = ''
+
+        api_exception = ApiException(status=401, reason='Unauthorized')
+        api_exception.body = 'Invalid bearer token'
+        mock_collect.side_effect = api_exception
+
+        with self.assertRaises(SystemExit) as cm, \
+                self.assertLogs('kubernetes-model-source', level='ERROR') as log_ctx:
+            main()
+
+        self.assertEqual(cm.exception.code, 1)
+        joined_logs = '\n'.join(log_ctx.output)
+        self.assertIn('401', joined_logs)
+        self.assertIn('Unauthorized', joined_logs)
+        self.assertIn('Invalid bearer token', joined_logs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

After upgrading our Rundeck version to 6.0.1, Kubernetes Rundeck plugin version 2.0.14 fails with 401 unauthorized. Our token didn't change and confirmed it is still valid (e.g sending it through the API as bearer token).

During the upgrade, the Kubernetes Python client also changed from `32.0.1` to `36.0.3`. Downgrading it back to `32.0.1` fixes the issue.

This PR is to fix token-based authentication when using Kubernetes Python client >= 35.0.0 (urllib3-based). Also adds error logging so auth failures are no longer silent.

## Changes

### Token auth fix (`common.py`)

The previous approach used a manual `Configuration()` object with `api_key['authorization']` - this breaks silently with a 401 on newer kubernetes client versions. The fix writes an in-memory kubeconfig dict to a `NamedTemporaryFile` and loads it via `config.load_kube_config(config_file=...)`, which works across all client versions. Config loading errors are also now logged via try/except.

### Error logging (`pods-resource-model.py`)

Wrapped the API call in `main()` with `try/except ApiException` to log the HTTP status, reason, and response body on failure. Without this, a wrong token silently exits with code 1 and no visible error.

## Testing

- All 66 existing unit tests pass

```bash
❯ python -m pytest contents/tests/ -v
==================================== test session starts ====================================
# ...

contents/tests/test_common.py::TestCommon::test_connect_config_file PASSED            [  1%]
contents/tests/test_common.py::TestCommon::test_connect_default_fallback PASSED       [  3%]
contents/tests/test_common.py::TestCommon::test_connect_incluster PASSED              [  4%]
contents/tests/test_common.py::TestCommon::test_connect_node_config_file PASSED       [  6%]
contents/tests/test_common.py::TestCommon::test_connect_url_and_token PASSED          [  7%]
contents/tests/test_common.py::TestCommon::test_copy_file_binary_exact PASSED         [  9%]
contents/tests/test_common.py::TestCommon::test_copy_file_binary_large PASSED         [ 10%]
contents/tests/test_common.py::TestCommon::test_copy_file_binary_small PASSED         [ 12%]
contents/tests/test_common.py::TestCommon::test_copy_file_empty PASSED                [ 13%]
contents/tests/test_common.py::TestCommon::test_copy_file_text_exact PASSED           [ 15%]
contents/tests/test_common.py::TestCommon::test_copy_file_text_large PASSED           [ 16%]
contents/tests/test_common.py::TestCommon::test_copy_file_text_small PASSED           [ 18%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_basic PASSED [ 19%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_command_and_args PASSED [ 21%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_environment_secrets PASSED [ 22%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_environments PASSED [ 24%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_image_pull_secrets PASSED [ 25%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_no_ports PASSED [ 27%]
contents/tests/test_common.py::TestCommon::test_create_pod_template_spec_resources PASSED [ 28%]
contents/tests/test_common.py::TestCommon::test_create_toleration_all_fields PASSED   [ 30%]
contents/tests/test_common.py::TestCommon::test_create_toleration_partial_fields PASSED [ 31%]
contents/tests/test_common.py::TestCommon::test_create_volume PASSED                  [ 33%]
contents/tests/test_common.py::TestCommon::test_create_volume_mount PASSED            [ 34%]
contents/tests/test_common.py::TestCommon::test_create_volume_mount_yaml_list PASSED  [ 36%]
contents/tests/test_common.py::TestCommon::test_create_volume_mount_yaml_single PASSED [ 37%]
contents/tests/test_common.py::TestCommon::test_delete_pod_not_found PASSED           [ 39%]
contents/tests/test_common.py::TestCommon::test_delete_pod_other_error PASSED         [ 40%]
contents/tests/test_common.py::TestCommon::test_delete_pod_success PASSED             [ 42%]
contents/tests/test_common.py::TestCommon::test_get_code_node_parameter_dictionary PASSED [ 43%]
contents/tests/test_common.py::TestCommon::test_load_liveness_readiness_probe_exec PASSED [ 45%]
contents/tests/test_common.py::TestCommon::test_load_liveness_readiness_probe_http_get PASSED [ 46%]
contents/tests/test_common.py::TestCommon::test_load_liveness_readiness_probe_http_get_port_only PASSED [ 48%]
contents/tests/test_common.py::TestCommon::test_log_pod_parameters PASSED             [ 50%]
contents/tests/test_common.py::TestCommon::test_object_encoder_datetime PASSED        [ 51%]
contents/tests/test_common.py::TestCommon::test_object_encoder_object PASSED          [ 53%]
contents/tests/test_common.py::TestCommon::test_parse_json PASSED                     [ 54%]
contents/tests/test_common.py::TestCommon::test_parse_json_fallback PASSED            [ 56%]
contents/tests/test_common.py::TestCommon::test_parse_ports PASSED                    [ 57%]
contents/tests/test_common.py::TestCommon::test_verify_pod_exists_found PASSED        [ 59%]
contents/tests/test_common.py::TestCommon::test_verify_pod_exists_not_found PASSED    [ 60%]
contents/tests/test_common.py::TestCommon::test_verify_pod_exists_other_error PASSED  [ 62%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_basic_running_pod PASSED [ 63%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_conditions_not_ready PASSED [ 65%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_config_file_env PASSED [ 66%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_custom_mapping PASSED [ 68%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_custom_tags PASSED [ 69%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_defaults_applied PASSED [ 71%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_emoticon_disabled PASSED [ 72%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_emoticon_enabled PASSED [ 74%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_labels_added PASSED [ 75%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_no_container_statuses PASSED [ 77%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_status_message_in_description PASSED [ 78%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_terminated_pod PASSED [ 80%]
contents/tests/test_pods_resource_model.py::TestNodeCollectData::test_waiting_pod PASSED [ 81%]
contents/tests/test_pods_resource_model.py::TestCollectPodsFromApi::test_all_namespaces_both_selectors PASSED [ 83%]
contents/tests/test_pods_resource_model.py::TestCollectPodsFromApi::test_all_namespaces_field_selector_only PASSED [ 84%]
contents/tests/test_pods_resource_model.py::TestCollectPodsFromApi::test_all_namespaces_label_selector_only PASSED [ 86%]
contents/tests/test_pods_resource_model.py::TestCollectPodsFromApi::test_all_namespaces_no_selectors PASSED [ 87%]
contents/tests/test_pods_resource_model.py::TestCollectPodsFromApi::test_namespaced PASSED [ 89%]
contents/tests/test_pods_resource_model.py::TestCollectPodsFromApi::test_namespaced_no_selectors PASSED [ 90%]
contents/tests/test_pods_resource_model.py::TestMain::test_main_emoticon_flag PASSED  [ 92%]
contents/tests/test_pods_resource_model.py::TestMain::test_main_empty_pod_list PASSED [ 93%]
contents/tests/test_pods_resource_model.py::TestMain::test_main_filters_only_running_when_running_true PASSED [ 95%]
contents/tests/test_pods_resource_model.py::TestMain::test_main_filters_terminated_when_not_running PASSED [ 96%]
contents/tests/test_pods_resource_model.py::TestMain::test_main_multiple_containers PASSED [ 98%]
contents/tests/test_pods_resource_model.py::TestMain::test_main_passes_env_to_collect PASSED [100%]

==================================== 66 passed in 0.57s =====================================
```

- Tested against Rundeck 6.0.1 with:
  - Kubernetes Python client `36.0.3`
  - Valid API token → pods list successfully
  - Invalid API token → `Kubernetes API error (HTTP 401): Unauthorized` logged with response body

---

**Maintainer notes:**
- Copilot flagged two issues, both addressed: (1) no test coverage for the new `ApiException` error-logging path in `pods-resource-model.py` — added `test_main_logs_and_exits_on_api_exception`; (2) the temp kubeconfig file's cleanup only ran inside the `finally` wrapping `load_kube_config`, so an earlier `yaml.dump()`/`.close()` failure would leak the file, and an `os.unlink` failure could mask the real config error.
- Went a step further on (2): switched from writing a temp kubeconfig file to disk to `config.load_kube_config_from_dict(kubeconfig_dict, persist_config=False)`, which goes through the same underlying loader as `load_kube_config(config_file=...)` (verified by tracing the client library source and a local smoke test confirming the token ends up correctly as `Bearer <token>` in the client config) but never writes the bearer token to disk at all. This removes the temp-file lifecycle entirely, so the leak/masking issue Copilot found no longer applies.
- Updated `test_connect_url_and_token` to match, and to actually assert on the kubeconfig dict contents (server URL, TLS verify flag, token) rather than just that a mock was called.
- Verified locally: `./gradlew build` passes, full Python test suite passes (67/67, up from 66).
