### PR TITLE
[RUN-4726] Reorder volumes before volume_mounts in Deployment and Pod steps

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -414,19 +414,19 @@ providers:
         required: false
         renderingOptions:
           groupName: Container
-      - name: volume_mounts
+      - name: volumes
         type: String
-        title: "Volume Mounts"
-        description: "Volume Mounts, yaml format "
+        title: "Volumes"
+        description: "Configure Volumes YAML format( https://kubernetes.io/docs/concepts/storage/persistent-volumes/). So far persistentVolumeClaim, hostPath, nfs, secret and configMap allowed"
         required: false
         renderingOptions:
           groupName: Container
           displayType: MULTI_LINE
           codeSyntaxMode: yaml
-      - name: volumes
+      - name: volume_mounts
         type: String
-        title: "Volumes"
-        description: "Configure Volumes YAML format( https://kubernetes.io/docs/concepts/storage/persistent-volumes/). So far persistentVolumeClaim, hostPath, nfs, secret and configMap allowed"
+        title: "Volume Mounts"
+        description: "Volume Mounts, yaml format "
         required: false
         renderingOptions:
           groupName: Container
@@ -2354,19 +2354,19 @@ providers:
         required: false
         renderingOptions:
           groupName: Container
-      - name: volume_mounts
+      - name: volumes
         type: String
-        title: "Volume Mounts"
-        description: "Volume Mounts, yaml format (https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/#configure-a-volume-for-a-pod)"
+        title: "Volumes"
+        description: "Configure Volumes YAML format( https://kubernetes.io/docs/concepts/storage/persistent-volumes/). So far persistentVolumeClaim, hostPath, nfs, secret and configMap allowed"
         required: false
         renderingOptions:
           groupName: Container
           displayType: MULTI_LINE
           codeSyntaxMode: yaml
-      - name: volumes
+      - name: volume_mounts
         type: String
-        title: "Volumes"
-        description: "Configure Volumes YAML format( https://kubernetes.io/docs/concepts/storage/persistent-volumes/). So far persistentVolumeClaim, hostPath, nfs, secret and configMap allowed"
+        title: "Volume Mounts"
+        description: "Volume Mounts, yaml format (https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/#configure-a-volume-for-a-pod)"
         required: false
         renderingOptions:
           groupName: Container


### PR DESCRIPTION
Deployment and Pod create steps showed Volume Mounts before Volumes; the Job step already had the correct order. That mismatch made it easy to paste config into the wrong field when copying between steps.

This PR reorders those fields in plugin.yaml so all three steps use Volumes → Volume Mounts, matching Kubernetes and the Job step. UI-only change — no code or behavior change.