### PR TITLE
Add tests for the pod step scripts and fix the bugs they surfaced

### DIFF
--- a/contents/common.py
+++ b/contents/common.py
@@ -70,22 +70,15 @@ def connect():
         config.load_incluster_config()
         return
 
-    if os.environ.get('RD_CONFIG_CONFIG_FILE'):
-        config_file = os.environ.get('RD_CONFIG_CONFIG_FILE')
-    elif os.environ.get('RD_NODE_KUBERNETES_CONFIG_FILE'):
-        config_file = os.environ.get('RD_NODE_KUBERNETES_CONFIG_FILE')
+    config_file = os.environ.get('RD_CONFIG_CONFIG_FILE') or os.environ.get('RD_NODE_KUBERNETES_CONFIG_FILE')
 
     verify_ssl = os.environ.get('RD_CONFIG_VERIFY_SSL')
     ssl_ca_cert = os.environ.get('RD_CONFIG_SSL_CA_CERT')
     url = os.environ.get('RD_CONFIG_URL')
-    
+
     token = os.environ.get('RD_CONFIG_TOKEN')
     if not token:
         token = os.environ.get('RD_CONFIG_TOKEN_STORAGE_PATH')
-
-    log.debug("config file")
-    log.debug(config_file)
-    log.debug("-------------------")
 
     if config_file:
         log.debug("getting settings from file %s", config_file)
@@ -209,16 +202,9 @@ def get_code_node_parameter_dictionary():
 
     :returns: A dictionary of name, namespace, and container
     """
-    container = None
-
-    if 'RD_CONFIG_CONTAINER_NAME' in os.environ:
-        container = os.environ.get('RD_CONFIG_CONTAINER_NAME')
-
-    if container is None and 'RD_CONFIG_CONTAINER' in os.environ:
-        container = os.environ.get('RD_CONFIG_CONTAINER')
-
-    if container is None and 'RD_NODE_DEFAULT_CONTAINER_NAME' in os.environ:
-        container = os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME')
+    container = (os.environ.get('RD_CONFIG_CONTAINER_NAME')
+                 or os.environ.get('RD_CONFIG_CONTAINER')
+                 or os.environ.get('RD_NODE_DEFAULT_CONTAINER_NAME'))
 
     return {
         'name': os.environ.get('RD_CONFIG_NAME', os.environ.get('RD_NODE_DEFAULT_NAME')),
@@ -245,10 +231,10 @@ def verify_pod_exists(name, namespace):
     except ApiException as e:
         if e.status != 404:
             log.exception("Unknown error:")
-            exit(1)
+            sys.exit(1)
     if not resp:
         log.error("Pod %s does not exist", name)
-        exit(1)
+        sys.exit(1)
 
 
 def parsePorts(data):
@@ -381,7 +367,7 @@ class ObjectEncoder(json.JSONEncoder):
 def parseJson(obj):
     try:
         return json.dumps(obj, cls=ObjectEncoder)
-    except:
+    except Exception:
         return obj
 
 
@@ -610,9 +596,9 @@ def run_interactive_command(name, namespace, container, command):
     err = yaml.safe_load(err)
     if err['status'] != "Success":
         log.error('Failed to run command')
-        log.error('Reason: ' + err['reason'])
-        log.error('Message: ' + err['message'])
-        log.error('Details: ' + ';'.join(map(lambda x: json.dumps(x), err['details']['causes'])))
+        log.error('Reason: %s', err['reason'])
+        log.error('Message: %s', err['message'])
+        log.error('Details: %s', ';'.join(json.dumps(x) for x in err['details']['causes']))
         error = True
 
     return (resp, error)
@@ -631,7 +617,12 @@ def delete_pod(data):
                                          propagation_policy='Foreground')
         return resp
 
-    except Exception as e:
+    except ApiException as e:
+        # A pod that is already gone is not a failure to delete, so report that
+        # by returning None. Anything else is raised so the caller can tell the
+        # two apart -- returning None for both left callers unable to notice a
+        # failed delete.
         if e.status != 404:
-            log.exception("Unknown error:")
-            return None
+            raise
+        log.warning("Pod %s not found in namespace %s", data["name"], data["namespace"])
+        return None

--- a/contents/pod-describe.py
+++ b/contents/pod-describe.py
@@ -10,16 +10,20 @@ from kubernetes.client.rest import ApiException
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
-log = logging.getLogger('kubernetes-model-source')
+log = logging.getLogger('kubernetes-pod-describe')
 
 
 def main():
 
-    pod_name = os.environ.get('RD_CONFIG_NAME')
-    namespace = os.environ.get('RD_CONFIG_NAMESPACE')
+    # get_core_node_parameter_list already prefers the step's own setting over
+    # the node's, for both name and namespace, and falls back to the "default"
+    # namespace last. Resolving name here but not namespace would lose the
+    # node's namespace whenever the step named a pod without one.
+    pod_name, namespace, _ = common.get_core_node_parameter_list()
 
     if not pod_name:
-        [pod_name, namespace, container] = common.get_core_node_parameter_list()
+        log.error("Pod name is not defined. Set RD_CONFIG_NAME or RD_NODE_DEFAULT_NAME.")
+        sys.exit(1)
 
     common.connect()
 
@@ -33,7 +37,7 @@ def main():
         print(common.parseJson(api_response.status))
 
     except ApiException:
-        log.exception("Exception deleting deployment:")
+        log.exception("Exception describing pod %s:", pod_name)
         sys.exit(1)
 
 

--- a/contents/pods-copy-file.py
+++ b/contents/pods-copy-file.py
@@ -1,35 +1,63 @@
 #!/usr/bin/env python -u
-import argparse
 import sys
 import os
 import common
 import logging
 
+from kubernetes import client
+from kubernetes.client.rest import ApiException
+
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
-log = logging.getLogger('kubernetes-model-source')
+log = logging.getLogger('kubernetes-copy-file')
 
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log.setLevel(logging.DEBUG)
-
-parser = argparse.ArgumentParser(
-    description='Execute a command string in the container.')
-parser.add_argument('pod', help='Pod')
-
-args = parser.parse_args()
 
 
 def main():
 
     common.connect()
 
-    [name, namespace, container] = common.get_core_node_parameter_list()
+    name, namespace, container = common.get_core_node_parameter_list()
+
+    if not name:
+        log.error("Pod name is not defined. Set RD_CONFIG_NAME or RD_NODE_DEFAULT_NAME.")
+        sys.exit(1)
+
+    if not container:
+        try:
+            core_v1 = client.CoreV1Api()
+            response = core_v1.read_namespaced_pod_status(
+                name=name,
+                namespace=namespace,
+                pretty=True
+            )
+        except ApiException as e:
+            log.error("Failed to read pod %s in namespace %s: %s", name, namespace, e.reason)
+            sys.exit(1)
+
+        if not response.spec.containers:
+            log.error("Pod %s has no containers", name)
+            sys.exit(1)
+
+        container = response.spec.containers[0].name
+    else:
+        common.verify_pod_exists(name, namespace)
+
     common.log_pod_parameters(log, {'name': name, 'namespace': namespace, 'container_name': container})
-    common.verify_pod_exists(name, namespace)
 
     source_file = os.environ.get('RD_FILE_COPY_FILE')
     destination_file = os.environ.get('RD_FILE_COPY_DESTINATION')
+
+    if not source_file:
+        log.error("Source file is not defined. Set RD_FILE_COPY_FILE.")
+        sys.exit(1)
+
+    if not destination_file:
+        log.error("Destination file is not defined. Set RD_FILE_COPY_DESTINATION.")
+        sys.exit(1)
 
     # force print destination to avoid error with node-executor
     print(destination_file)
@@ -39,7 +67,11 @@ def main():
     destination_path = os.path.dirname(destination_file)
     destination_file_name = os.path.basename(destination_file)
 
-    common.copy_file(name, namespace, container, source_file, destination_path, destination_file_name)
+    try:
+        common.copy_file(name, namespace, container, source_file, destination_path, destination_file_name)
+    except Exception:
+        log.exception("Failed to copy file to pod %s", name)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/contents/pods-create.py
+++ b/contents/pods-create.py
@@ -20,8 +20,17 @@ if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
 
 
 def create_pod(data):
-    labels_array = data["labels"].split(',')
-    labels = dict(s.split('=') for s in labels_array)
+    # split('=', 1) so a value containing '=' does not raise on unpacking, and
+    # an entry without '=' is reported rather than raising a bare ValueError.
+    labels = {}
+    for entry in (data["labels"] or '').split(','):
+        if not entry:
+            continue
+        if '=' not in entry:
+            log.error("Labels must be key=value pairs separated by commas, got: %s", entry)
+            sys.exit(1)
+        key, value = entry.split('=', 1)
+        labels[key] = value
 
     metadata = client.V1ObjectMeta(labels=labels,
                                    namespace=data["namespace"],
@@ -82,7 +91,7 @@ def main():
     if os.environ.get('RD_CONFIG_RESOURCES_REQUESTS'):
         rr = os.environ.get('RD_CONFIG_RESOURCES_REQUESTS')
         data["resources_requests"] = rr
-    
+
     if os.environ.get('RD_CONFIG_RESOURCES_LIMITS'):
         rl = os.environ.get('RD_CONFIG_RESOURCES_LIMITS')
         data["resources_limits"] = rl
@@ -94,21 +103,23 @@ def main():
         data["image_pull_secrets"] = os.environ.get('RD_CONFIG_IMAGEPULLSECRETS')
 
     pod = create_pod(data)
-    resp = None
+
     try:
         resp = api.create_namespaced_pod(namespace=data['namespace'],
                                          body=pod,
                                          pretty="True")
-
-        print("Pod Created successfully")
-
     except ApiException:
-        log.exception("Exception creating pod:")
-        exit(1)
+        log.exception("Exception creating pod %s:", data['name'])
+        sys.exit(1)
 
+    # Report the outcome only once it is known. Announcing success before
+    # checking the response could print both that the pod was created and that
+    # it does not exist.
     if not resp:
-        print("Pod %s does not exist" % data['name'])
-        exit(1)
+        log.error("Pod %s was not created", data['name'])
+        sys.exit(1)
+
+    print("Pod Created successfully")
 
 
 if __name__ == '__main__':

--- a/contents/pods-delete.py
+++ b/contents/pods-delete.py
@@ -22,13 +22,22 @@ def main():
 
     data = common.get_code_node_parameter_dictionary()
 
+    if not data["name"]:
+        log.error("Pod name is not defined. Set RD_CONFIG_NAME or RD_NODE_DEFAULT_NAME.")
+        sys.exit(1)
+
     common.connect()
 
     try:
-        common.delete_pod(data)
-        print("Pod deleted successfully")
+        resp = common.delete_pod(data)
+        if resp:
+            print("Pod deleted successfully")
+        else:
+            # Already gone. Deleting is idempotent, so a cleanup job that runs
+            # twice should not fail the second time.
+            print("Pod %s not found; nothing to delete" % data["name"])
     except ApiException:
-        log.exception("Exception deleting deployment:")
+        log.exception("Exception deleting pod %s:", data["name"])
         sys.exit(1)
 
 

--- a/contents/pods-node-executor.py
+++ b/contents/pods-node-executor.py
@@ -5,10 +5,11 @@ import os
 import common
 
 from kubernetes import client
+from kubernetes.client.rest import ApiException
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
-log = logging.getLogger('kubernetes-model-source')
+log = logging.getLogger('kubernetes-node-executor')
 
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log.setLevel(logging.DEBUG)
@@ -18,26 +19,40 @@ def main():
 
     common.connect()
 
-    [name, namespace, container] = common.get_core_node_parameter_list()
+    name, namespace, container = common.get_core_node_parameter_list()
+
+    if not name:
+        log.error("Pod name is not defined. Set RD_CONFIG_NAME or RD_NODE_DEFAULT_NAME.")
+        sys.exit(1)
 
     if not container:
-        core_v1 = client.CoreV1Api()
-        response = core_v1.read_namespaced_pod_status(
-            name=name,
-            namespace=namespace,
-            pretty="True"
-        )
+        try:
+            core_v1 = client.CoreV1Api()
+            response = core_v1.read_namespaced_pod_status(
+                name=name,
+                namespace=namespace,
+                pretty=True
+            )
+        except ApiException as e:
+            log.error("Failed to read pod %s in namespace %s: %s", name, namespace, e.reason)
+            sys.exit(1)
+
+        if not response.spec.containers:
+            log.error("Pod %s has no containers", name)
+            sys.exit(1)
+
         container = response.spec.containers[0].name
+    else:
+        common.verify_pod_exists(name, namespace)
 
     common.log_pod_parameters(log, {'name': name, 'namespace': namespace, 'container_name': container})
-    common.verify_pod_exists(name, namespace)
 
     shell = os.environ.get('RD_CONFIG_SHELL')
 
-    if 'RD_EXEC_COMMAND' in os.environ:
-        command = os.environ['RD_EXEC_COMMAND']
-    else:
-        command = os.environ['RD_CONFIG_COMMAND']
+    command = os.environ.get('RD_EXEC_COMMAND') or os.environ.get('RD_CONFIG_COMMAND')
+    if not command:
+        log.error("No command specified. Set RD_EXEC_COMMAND or RD_CONFIG_COMMAND.")
+        sys.exit(1)
 
     log.debug("Command: %s ", command)
 
@@ -47,7 +62,7 @@ def main():
         '-c',
         command]
 
-    resp, error = common.run_interactive_command(name, namespace, container, exec_command)
+    _, error = common.run_interactive_command(name, namespace, container, exec_command)
 
     if error:
         log.error("error running script")

--- a/contents/pods-read-logs.py
+++ b/contents/pods-read-logs.py
@@ -6,11 +6,10 @@ import common
 
 from kubernetes import client
 from kubernetes.client.rest import ApiException
-from kubernetes import watch
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO,
                     format='%(message)s')
-log = logging.getLogger('kubernetes-model-source')
+log = logging.getLogger('kubernetes-read-logs')
 
 
 def main():
@@ -19,52 +18,49 @@ def main():
         log.debug("Log level configured for DEBUG")
 
     data = common.get_code_node_parameter_dictionary()
-    data["follow"] = os.environ.get('RD_CONFIG_FOLLOW')
+    follow = os.environ.get('RD_CONFIG_FOLLOW') == 'true'
+
+    if not data["name"]:
+        log.error("Pod name is not defined. Set RD_CONFIG_NAME or RD_NODE_DEFAULT_NAME.")
+        sys.exit(1)
+
+    tail_lines_raw = os.environ.get('RD_CONFIG_NUMBER_OF_LINES')
+    tail_lines = None
+    if tail_lines_raw:
+        try:
+            tail_lines = int(tail_lines_raw)
+        except ValueError:
+            log.error("RD_CONFIG_NUMBER_OF_LINES must be a number, got: %s", tail_lines_raw)
+            sys.exit(1)
 
     common.connect()
 
     try:
         v1 = client.CoreV1Api()
 
-        if data["follow"] == 'true':
+        kwargs = dict(
+            namespace=data["namespace"],
+            name=data["name"],
+        )
+        if tail_lines is not None:
+            kwargs['tail_lines'] = tail_lines
+        if data["container_name"]:
+            kwargs['container'] = data["container_name"]
 
-            if data["container_name"]:
-                w = watch.Watch()
-                for line in w.stream(v1.read_namespaced_pod_log,
-                                     namespace=data["namespace"],
-                                     name=data["name"],
-                                     tail_lines=os.environ.get('RD_CONFIG_NUMBER_OF_LINES'),
-                                     follow=False):
-                    print(line.encode('ascii', 'ignore'))
-            else:
-                w = watch.Watch()
-                for line in w.stream(v1.read_namespaced_pod_log,
-                                     container=data["container_name"],
-                                     namespace=data["namespace"],
-                                     name=data["name"],
-                                     tail_lines=os.environ.get('RD_CONFIG_NUMBER_OF_LINES'),
-                                     follow=False):
-                    print(line.encode('ascii', 'ignore'))
+        if follow:
+            from kubernetes import watch
+            w = watch.Watch()
+            for line in w.stream(v1.read_namespaced_pod_log, follow=True, **kwargs):
+                print(line)
         else:
-            if data["container_name"]:
-                ret = v1.read_namespaced_pod_log(
-                    container=data["container_name"],
-                    namespace=data["namespace"],
-                    name=data["name"],
-                    tail_lines=os.environ.get('RD_CONFIG_NUMBER_OF_LINES'),
-                    _preload_content=False
-                )
-            else:
-                ret = v1.read_namespaced_pod_log(
-                    namespace=data["namespace"],
-                    name=data["name"],
-                    tail_lines=os.environ.get('RD_CONFIG_NUMBER_OF_LINES'),
-                    _preload_content=False
-                )
-            print(ret.read())
+            ret = v1.read_namespaced_pod_log(_preload_content=False, **kwargs)
+            # errors='replace' so non-UTF-8 container output still reaches the
+            # operator; a UnicodeDecodeError here is not an ApiException and
+            # would escape as an unhandled traceback with no logs shown.
+            print(ret.read().decode('utf-8', errors='replace'))
 
     except ApiException:
-        log.exception("Exception error creating:")
+        log.exception("Exception reading pod logs:")
         sys.exit(1)
 
 

--- a/contents/pods-run-script.py
+++ b/contents/pods-run-script.py
@@ -6,47 +6,32 @@ import tempfile
 
 import common
 
-from kubernetes.client.api import core_v1_api
-from kubernetes.client.rest import ApiException
 from kubernetes import client
+from kubernetes.client.rest import ApiException
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO,
                     format='%(levelname)s: %(name)s: %(message)s')
-log = logging.getLogger('kubernetes-model-source')
+log = logging.getLogger('kubernetes-run-script')
 
 if os.environ.get('RD_JOB_LOGLEVEL') == 'DEBUG':
     log.setLevel(logging.DEBUG)
 
-PY = sys.version_info[0]
-
-
 def main():
     common.connect()
-    api = core_v1_api.CoreV1Api()
+    api = client.CoreV1Api()
 
-    [name, namespace, container] = common.get_core_node_parameter_list()
+    name, namespace, container = common.get_core_node_parameter_list()
+
+    if not name:
+        log.error("Pod name is not defined. Set RD_CONFIG_NAME or RD_NODE_DEFAULT_NAME.")
+        sys.exit(1)
+
     common.verify_pod_exists(name, namespace)
 
-    delete_on_fail = False
-    if os.environ.get('RD_CONFIG_DELETEONFAIL') == 'true':
-        delete_on_fail = True
-
-    resp = None
-    try:
-        resp = api.read_namespaced_pod(name=name,
-                                       namespace=namespace)
-    except ApiException as e:
-        if e.status != 404:
-            log.exception("Unknown error:")
-            exit(1)
-
-    if not resp:
-        log.error("Pod %s does not exits.", name)
-        exit(1)
+    delete_on_fail = os.environ.get('RD_CONFIG_DELETEONFAIL') == 'true'
 
     if not container:
-        core_v1 = client.CoreV1Api()
-        response = core_v1.read_namespaced_pod_status(
+        response = api.read_namespaced_pod_status(
             name=name,
             namespace=namespace,
             pretty="True"
@@ -56,15 +41,17 @@ def main():
             container = response.spec.containers[0].name
         else:
             log.error("Container not found")
-            exit(1)
+            sys.exit(1)
 
     common.log_pod_parameters(log, {'name': name, 'namespace': namespace, 'container_name': container})
 
     script = os.environ.get('RD_CONFIG_SCRIPT')
 
-    # Python 3 expects bytes string to transfer the data.
-    if PY == 3:
-        script = script.encode('utf-8')
+    if not script:
+        log.error("No script provided. Set RD_CONFIG_SCRIPT.")
+        sys.exit(1)
+
+    script = script.encode('utf-8')
 
     log.debug("--------------------------")
     log.debug("Pod Name:  %s", name)
@@ -72,24 +59,18 @@ def main():
     log.debug("Container: %s", container)
     log.debug("--------------------------")
 
-    invocation = "/bin/bash"
-    if 'RD_CONFIG_INVOCATION' in os.environ:
-        invocation = os.environ.get('RD_CONFIG_INVOCATION')
-
-    destination_path = "/tmp"
-
-    if 'RD_NODE_FILE_COPY_DESTINATION_DIR' in os.environ:
-        destination_path = os.environ.get('RD_NODE_FILE_COPY_DESTINATION_DIR')
+    invocation = os.environ.get('RD_CONFIG_INVOCATION', '/bin/bash')
+    destination_path = os.environ.get('RD_NODE_FILE_COPY_DESTINATION_DIR', '/tmp')
 
     temp = tempfile.NamedTemporaryFile()
     destination_file_name = os.path.basename(temp.name)
-    full_path = destination_path + "/" + destination_file_name
+    full_path = os.path.join(destination_path, destination_file_name)
 
     try:
         temp.write(script)
         temp.seek(0)
 
-        log.debug("coping script from %s to %s", temp.name, full_path)
+        log.debug("copying script from %s to %s", temp.name, full_path)
 
         common.copy_file(name=name,
                          namespace=namespace,
@@ -140,8 +121,13 @@ def main():
         if delete_on_fail:
             log.info("removing POD on fail")
             data = {"name": name, "namespace": namespace}
-            common.delete_pod(data)
-            log.info("POD deleted")
+            # Cleanup runs because the script already failed. Report a cleanup
+            # failure without letting it mask the failure that caused it.
+            try:
+                common.delete_pod(data)
+                log.info("POD deleted")
+            except ApiException:
+                log.exception("Failed to remove POD %s after script failure:", name)
         sys.exit(1)
 
     rm_command = ["rm", full_path]

--- a/contents/tests/test_common.py
+++ b/contents/tests/test_common.py
@@ -459,8 +459,10 @@ class TestCommon(unittest.TestCase):
         from kubernetes.client.rest import ApiException
         mock_api = mock_api_class.return_value
         mock_api.delete_namespaced_pod.side_effect = ApiException(status=500)
-        result = common.delete_pod({'name': 'my-pod', 'namespace': 'default'})
-        self.assertIsNone(result)
+        # Only a missing pod returns None. Swallowing other errors the same way
+        # left callers unable to tell a failed delete from an absent pod.
+        with self.assertRaises(ApiException):
+            common.delete_pod({'name': 'my-pod', 'namespace': 'default'})
 
 
     def _run_copy_file_test(self, content, suffix, dest_path, dest_name, expected_arcname):

--- a/contents/tests/test_pod_describe.py
+++ b/contents/tests/test_pod_describe.py
@@ -61,6 +61,30 @@ class TestPodDescribe(unittest.TestCase):
 
     @patch.object(pod_describe.client, 'CoreV1Api')
     @patch.object(pod_describe.common, 'connect')
+    def test_main_uses_node_namespace_when_step_sets_only_the_name(
+            self, mock_connect, mock_api_class):
+        # A node in namespace "prod" with the step's Pod Name filled in but
+        # Namespace blank must still describe prod/my-pod, not default/my-pod.
+        os.environ['RD_CONFIG_NAME'] = 'my-pod'
+        os.environ['RD_NODE_DEFAULT_NAMESPACE'] = 'prod'
+        mock_api_class.return_value.read_namespaced_pod.return_value = MagicMock(
+            status={'phase': 'Running'})
+
+        with redirect_stdout(io.StringIO()):
+            pod_describe.main()
+
+        mock_api_class.return_value.read_namespaced_pod.assert_called_once_with(
+            name='my-pod', namespace='prod')
+
+    @patch.object(pod_describe.client, 'CoreV1Api')
+    @patch.object(pod_describe.common, 'connect')
+    def test_main_exits_when_pod_name_is_missing(self, mock_connect, mock_api_class):
+        with self.assertRaises(SystemExit) as cm:
+            pod_describe.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pod_describe.client, 'CoreV1Api')
+    @patch.object(pod_describe.common, 'connect')
     def test_main_exits_on_api_exception(self, mock_connect, mock_api_class):
         os.environ['RD_CONFIG_NAME'] = 'my-pod'
         os.environ['RD_CONFIG_NAMESPACE'] = 'prod'

--- a/contents/tests/test_pod_describe.py
+++ b/contents/tests/test_pod_describe.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for pod-describe.py.
+
+pod-describe.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pod_describe.common.
+"""
+
+import importlib
+import io
+import os
+import sys
+import unittest
+
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.rest import ApiException
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pod_describe = importlib.import_module('pod-describe')
+
+
+class TestPodDescribe(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    @patch.object(pod_describe.client, 'CoreV1Api')
+    @patch.object(pod_describe.common, 'connect')
+    def test_main_describes_pod_named_by_config(self, mock_connect, mock_api_class):
+        os.environ['RD_CONFIG_NAME'] = 'my-pod'
+        os.environ['RD_CONFIG_NAMESPACE'] = 'prod'
+        mock_api_class.return_value.read_namespaced_pod.return_value = MagicMock(
+            status={'phase': 'Running'})
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pod_describe.main()
+
+        mock_api_class.return_value.read_namespaced_pod.assert_called_once_with(
+            name='my-pod', namespace='prod')
+        self.assertIn('Running', out.getvalue())
+
+    @patch.object(pod_describe.client, 'CoreV1Api')
+    @patch.object(pod_describe.common, 'connect')
+    @patch.object(pod_describe.common, 'get_core_node_parameter_list')
+    def test_main_falls_back_to_node_parameters(
+            self, mock_params, mock_connect, mock_api_class):
+        mock_params.return_value = ['node-pod', 'staging', 'app']
+        mock_api_class.return_value.read_namespaced_pod.return_value = MagicMock(
+            status={'phase': 'Running'})
+
+        with redirect_stdout(io.StringIO()):
+            pod_describe.main()
+
+        mock_api_class.return_value.read_namespaced_pod.assert_called_once_with(
+            name='node-pod', namespace='staging')
+
+    @patch.object(pod_describe.client, 'CoreV1Api')
+    @patch.object(pod_describe.common, 'connect')
+    def test_main_exits_on_api_exception(self, mock_connect, mock_api_class):
+        os.environ['RD_CONFIG_NAME'] = 'my-pod'
+        os.environ['RD_CONFIG_NAMESPACE'] = 'prod'
+        mock_api_class.return_value.read_namespaced_pod.side_effect = ApiException(
+            status=404, reason='Not Found')
+
+        with self.assertRaises(SystemExit) as cm:
+            pod_describe.main()
+        self.assertEqual(1, cm.exception.code)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_copy_file.py
+++ b/contents/tests/test_pods_copy_file.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for pods-copy-file.py.
+
+pods-copy-file.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pods_copy_file.common.
+"""
+
+import importlib
+import io
+import os
+import sys
+import unittest
+
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pods_copy_file = importlib.import_module('pods-copy-file')
+
+
+class TestPodsCopyFile(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    @patch.object(pods_copy_file.common, 'copy_file')
+    @patch.object(pods_copy_file.common, 'log_pod_parameters')
+    @patch.object(pods_copy_file.common, 'verify_pod_exists')
+    @patch.object(pods_copy_file.common, 'get_core_node_parameter_list')
+    @patch.object(pods_copy_file.common, 'connect')
+    def test_main_copies_file_to_pod(self, mock_connect, mock_params, mock_verify,
+                                     mock_log, mock_copy):
+        os.environ['RD_FILE_COPY_FILE'] = '/local/script.sh'
+        os.environ['RD_FILE_COPY_DESTINATION'] = '/tmp/script.sh'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_copy_file.main()
+
+        mock_copy.assert_called_once_with(
+            'my-pod', 'default', 'app', '/local/script.sh', '/tmp', 'script.sh')
+        self.assertIn('/tmp/script.sh', out.getvalue())
+
+    @patch.object(pods_copy_file.common, 'get_core_node_parameter_list')
+    @patch.object(pods_copy_file.common, 'connect')
+    def test_main_exits_when_pod_name_is_missing(self, mock_connect, mock_params):
+        os.environ['RD_FILE_COPY_FILE'] = '/local/script.sh'
+        os.environ['RD_FILE_COPY_DESTINATION'] = '/tmp/script.sh'
+        mock_params.return_value = [None, 'default', 'app']
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_copy_file.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_copy_file.common, 'verify_pod_exists')
+    @patch.object(pods_copy_file.common, 'get_core_node_parameter_list')
+    @patch.object(pods_copy_file.common, 'connect')
+    def test_main_exits_when_source_file_is_missing(self, mock_connect, mock_params,
+                                                    mock_verify):
+        os.environ['RD_FILE_COPY_DESTINATION'] = '/tmp/script.sh'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_copy_file.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_copy_file.common, 'copy_file')
+    @patch.object(pods_copy_file.common, 'log_pod_parameters')
+    @patch.object(pods_copy_file.common, 'verify_pod_exists')
+    @patch.object(pods_copy_file.common, 'get_core_node_parameter_list')
+    @patch.object(pods_copy_file.common, 'connect')
+    def test_main_exits_when_copy_fails(self, mock_connect, mock_params, mock_verify,
+                                        mock_log, mock_copy):
+        os.environ['RD_FILE_COPY_FILE'] = '/local/script.sh'
+        os.environ['RD_FILE_COPY_DESTINATION'] = '/tmp/script.sh'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        mock_copy.side_effect = RuntimeError('stream closed')
+
+        with redirect_stdout(io.StringIO()), self.assertRaises(SystemExit) as cm:
+            pods_copy_file.main()
+        self.assertEqual(1, cm.exception.code)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_create.py
+++ b/contents/tests/test_pods_create.py
@@ -41,6 +41,23 @@ class TestCreatePod(unittest.TestCase):
     def setUp(self):
         os.environ.clear()
 
+    def test_create_pod_keeps_equals_signs_in_label_values(self):
+        # Splitting on every '=' raised "too many values to unpack" instead of
+        # saying what was wrong with the input.
+        pod = pods_create.create_pod(create_data(labels='token=a=b'))
+        self.assertEqual({'token': 'a=b'}, pod.metadata.labels)
+
+    def test_create_pod_reports_labels_that_are_not_pairs(self):
+        with self.assertRaises(SystemExit) as cm:
+            pods_create.create_pod(create_data(labels='notapair'))
+        self.assertEqual(1, cm.exception.code)
+
+    def test_create_pod_tolerates_empty_labels(self):
+        # labels is required in plugin.yaml, but an empty value satisfies that
+        # check and used to reach ''.split('=') as a bare ValueError.
+        pod = pods_create.create_pod(create_data(labels=''))
+        self.assertEqual({}, pod.metadata.labels)
+
     def test_create_pod_builds_metadata_from_labels(self):
         pod = pods_create.create_pod(create_data())
 
@@ -91,6 +108,21 @@ class TestPodsCreateMain(unittest.TestCase):
         with redirect_stdout(io.StringIO()), self.assertRaises(SystemExit) as cm:
             pods_create.main()
         self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_create.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_create.common, 'log_pod_parameters')
+    @patch.object(pods_create.common, 'connect')
+    def test_main_does_not_report_success_when_nothing_was_created(
+            self, mock_connect, mock_log, mock_api_class):
+        self._configure()
+        mock_api_class.return_value.create_namespaced_pod.return_value = None
+
+        out = io.StringIO()
+        with redirect_stdout(out), self.assertRaises(SystemExit) as cm:
+            pods_create.main()
+
+        self.assertEqual(1, cm.exception.code)
+        self.assertNotIn('Pod Created successfully', out.getvalue())
 
     @patch.object(pods_create.core_v1_api, 'CoreV1Api')
     @patch.object(pods_create.common, 'log_pod_parameters')

--- a/contents/tests/test_pods_create.py
+++ b/contents/tests/test_pods_create.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for pods-create.py.
+
+pods-create.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pods_create.common.
+"""
+
+import importlib
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.rest import ApiException
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pods_create = importlib.import_module('pods-create')
+
+
+def create_data(**overrides):
+    data = {
+        'name': 'my-pod',
+        'namespace': 'default',
+        'container_name': 'app',
+        'api_version': 'v1',
+        'image': 'nginx:latest',
+        'labels': 'app=web,env=prod',
+        'ports': None,
+    }
+    data.update(overrides)
+    return data
+
+
+class TestCreatePod(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    def test_create_pod_builds_metadata_from_labels(self):
+        pod = pods_create.create_pod(create_data())
+
+        self.assertEqual('Pod', pod.kind)
+        self.assertEqual('v1', pod.api_version)
+        self.assertEqual('my-pod', pod.metadata.name)
+        self.assertEqual('default', pod.metadata.namespace)
+        self.assertEqual({'app': 'web', 'env': 'prod'}, pod.metadata.labels)
+
+
+class TestPodsCreateMain(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    def _configure(self):
+        os.environ['RD_CONFIG_NAME'] = 'my-pod'
+        os.environ['RD_CONFIG_NAMESPACE'] = 'default'
+        os.environ['RD_CONFIG_CONTAINER_NAME'] = 'app'
+        os.environ['RD_CONFIG_API_VERSION'] = 'v1'
+        os.environ['RD_CONFIG_IMAGE'] = 'nginx:latest'
+        os.environ['RD_CONFIG_LABELS'] = 'app=web'
+
+    @patch.object(pods_create.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_create.common, 'log_pod_parameters')
+    @patch.object(pods_create.common, 'connect')
+    def test_main_creates_the_pod(self, mock_connect, mock_log, mock_api_class):
+        self._configure()
+        mock_api_class.return_value.create_namespaced_pod.return_value = MagicMock()
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_create.main()
+
+        kwargs = mock_api_class.return_value.create_namespaced_pod.call_args[1]
+        self.assertEqual('default', kwargs['namespace'])
+        self.assertEqual('my-pod', kwargs['body'].metadata.name)
+        self.assertIn('Pod Created successfully', out.getvalue())
+
+    @patch.object(pods_create.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_create.common, 'log_pod_parameters')
+    @patch.object(pods_create.common, 'connect')
+    def test_main_exits_on_api_exception(self, mock_connect, mock_log, mock_api_class):
+        self._configure()
+        mock_api_class.return_value.create_namespaced_pod.side_effect = ApiException(
+            status=409, reason='AlreadyExists')
+
+        with redirect_stdout(io.StringIO()), self.assertRaises(SystemExit) as cm:
+            pods_create.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_create.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_create.common, 'log_pod_parameters')
+    @patch.object(pods_create.common, 'connect')
+    def test_main_passes_optional_settings_through(
+            self, mock_connect, mock_log, mock_api_class):
+        self._configure()
+        os.environ['RD_CONFIG_PORTS'] = '8080'
+        os.environ['RD_CONFIG_ENVIRONMENTS'] = 'KEY=value'
+        mock_api_class.return_value.create_namespaced_pod.return_value = MagicMock()
+
+        with redirect_stdout(io.StringIO()):
+            pods_create.main()
+
+        container = mock_api_class.return_value.create_namespaced_pod.call_args[1][
+            'body'].spec.containers[0]
+        self.assertEqual('nginx:latest', container.image)
+        self.assertEqual('app', container.name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_delete.py
+++ b/contents/tests/test_pods_delete.py
@@ -1,0 +1,62 @@
+"""
+Unit tests for pods-delete.py.
+
+pods-delete.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pods_delete.common.
+"""
+
+import importlib
+import io
+import os
+import sys
+import unittest
+
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+from kubernetes.client.rest import ApiException
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pods_delete = importlib.import_module('pods-delete')
+
+
+def node_params(name='my-pod', namespace='default', container='app'):
+    return {'name': name, 'namespace': namespace, 'container_name': container}
+
+class TestPodsDelete(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    @patch.object(pods_delete.common, 'delete_pod')
+    @patch.object(pods_delete.common, 'connect')
+    @patch.object(pods_delete.common, 'get_code_node_parameter_dictionary')
+    def test_main_reports_success_when_delete_returns_a_response(
+            self, mock_params, mock_connect, mock_delete):
+        mock_params.return_value = node_params()
+        mock_delete.return_value = MagicMock()
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_delete.main()
+
+        mock_delete.assert_called_once()
+        self.assertIn('Pod deleted successfully', out.getvalue())
+
+    @patch.object(pods_delete.common, 'delete_pod')
+    @patch.object(pods_delete.common, 'connect')
+    @patch.object(pods_delete.common, 'get_code_node_parameter_dictionary')
+    def test_main_exits_on_api_exception(self, mock_params, mock_connect, mock_delete):
+        mock_params.return_value = node_params()
+        mock_delete.side_effect = ApiException(status=500, reason='boom')
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_delete.main()
+        self.assertEqual(1, cm.exception.code)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_delete.py
+++ b/contents/tests/test_pods_delete.py
@@ -57,8 +57,10 @@ class TestPodsDelete(unittest.TestCase):
         mock_delete.return_value = None
 
         out = io.StringIO()
-        pods_delete.main()
+        with redirect_stdout(out):
+            pods_delete.main()
 
+        self.assertIn('not found', out.getvalue())
         self.assertNotIn('Pod deleted successfully', out.getvalue())
 
     @patch.object(pods_delete.common, 'delete_pod')

--- a/contents/tests/test_pods_delete.py
+++ b/contents/tests/test_pods_delete.py
@@ -49,6 +49,47 @@ class TestPodsDelete(unittest.TestCase):
     @patch.object(pods_delete.common, 'delete_pod')
     @patch.object(pods_delete.common, 'connect')
     @patch.object(pods_delete.common, 'get_code_node_parameter_dictionary')
+    def test_main_succeeds_when_pod_is_already_gone(
+            self, mock_params, mock_connect, mock_delete):
+        # Deleting is idempotent: a cleanup job that runs twice must not fail
+        # the second time. delete_pod returns None only for a missing pod.
+        mock_params.return_value = node_params()
+        mock_delete.return_value = None
+
+        out = io.StringIO()
+        pods_delete.main()
+
+        self.assertNotIn('Pod deleted successfully', out.getvalue())
+
+    @patch.object(pods_delete.common, 'delete_pod')
+    @patch.object(pods_delete.common, 'connect')
+    @patch.object(pods_delete.common, 'get_code_node_parameter_dictionary')
+    def test_main_exits_when_delete_fails(
+            self, mock_params, mock_connect, mock_delete):
+        # A real failure must not report success -- upstream printed
+        # "Pod deleted successfully" and exited 0 for every failed delete.
+        mock_params.return_value = node_params()
+        mock_delete.side_effect = ApiException(status=500, reason='boom')
+
+        out = io.StringIO()
+        with redirect_stdout(out), self.assertRaises(SystemExit) as cm:
+            pods_delete.main()
+
+        self.assertEqual(1, cm.exception.code)
+        self.assertNotIn('Pod deleted successfully', out.getvalue())
+
+    @patch.object(pods_delete.common, 'connect')
+    @patch.object(pods_delete.common, 'get_code_node_parameter_dictionary')
+    def test_main_exits_when_pod_name_is_missing(self, mock_params, mock_connect):
+        mock_params.return_value = node_params(name=None)
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_delete.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_delete.common, 'delete_pod')
+    @patch.object(pods_delete.common, 'connect')
+    @patch.object(pods_delete.common, 'get_code_node_parameter_dictionary')
     def test_main_exits_on_api_exception(self, mock_params, mock_connect, mock_delete):
         mock_params.return_value = node_params()
         mock_delete.side_effect = ApiException(status=500, reason='boom')

--- a/contents/tests/test_pods_node_executor.py
+++ b/contents/tests/test_pods_node_executor.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for pods-node-executor.py.
+
+pods-node-executor.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pods_node_executor.common.
+"""
+
+import importlib
+import os
+import sys
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pods_node_executor = importlib.import_module('pods-node-executor')
+
+
+class TestPodsNodeExecutor(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    @patch.object(pods_node_executor.common, 'run_interactive_command')
+    @patch.object(pods_node_executor.common, 'verify_pod_exists')
+    @patch.object(pods_node_executor.common, 'log_pod_parameters')
+    @patch.object(pods_node_executor.common, 'get_core_node_parameter_list')
+    @patch.object(pods_node_executor.common, 'connect')
+    def test_main_runs_command_in_configured_container(
+            self, mock_connect, mock_params, mock_log, mock_verify, mock_run):
+        os.environ['RD_CONFIG_SHELL'] = '/bin/bash'
+        os.environ['RD_CONFIG_COMMAND'] = 'echo hello'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        mock_run.return_value = (MagicMock(), False)
+
+        pods_node_executor.main()
+
+        name, namespace, container, exec_command = mock_run.call_args[0]
+        self.assertEqual('my-pod', name)
+        self.assertEqual('app', container)
+        self.assertEqual(['/bin/bash', '-c', 'echo hello'], exec_command)
+
+    @patch.object(pods_node_executor.common, 'run_interactive_command')
+    @patch.object(pods_node_executor.common, 'verify_pod_exists')
+    @patch.object(pods_node_executor.common, 'log_pod_parameters')
+    @patch.object(pods_node_executor.common, 'get_core_node_parameter_list')
+    @patch.object(pods_node_executor.common, 'connect')
+    def test_main_prefers_exec_command_over_config_command(
+            self, mock_connect, mock_params, mock_log, mock_verify, mock_run):
+        os.environ['RD_CONFIG_SHELL'] = '/bin/bash'
+        os.environ['RD_CONFIG_COMMAND'] = 'from-config'
+        os.environ['RD_EXEC_COMMAND'] = 'from-exec'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        mock_run.return_value = (MagicMock(), False)
+
+        pods_node_executor.main()
+
+        self.assertEqual(['/bin/bash', '-c', 'from-exec'], mock_run.call_args[0][3])
+
+    @patch.object(pods_node_executor.client, 'CoreV1Api')
+    @patch.object(pods_node_executor.common, 'run_interactive_command')
+    @patch.object(pods_node_executor.common, 'verify_pod_exists')
+    @patch.object(pods_node_executor.common, 'log_pod_parameters')
+    @patch.object(pods_node_executor.common, 'get_core_node_parameter_list')
+    @patch.object(pods_node_executor.common, 'connect')
+    def test_main_resolves_first_container_when_none_configured(
+            self, mock_connect, mock_params, mock_log, mock_verify, mock_run, mock_api_class):
+        os.environ['RD_CONFIG_SHELL'] = '/bin/bash'
+        os.environ['RD_CONFIG_COMMAND'] = 'echo hello'
+        mock_params.return_value = ['my-pod', 'default', None]
+        status = MagicMock()
+        status.spec.containers = [MagicMock(name='first')]
+        status.spec.containers[0].name = 'sidecar'
+        mock_api_class.return_value.read_namespaced_pod_status.return_value = status
+        mock_run.return_value = (MagicMock(), False)
+
+        pods_node_executor.main()
+
+        self.assertEqual('sidecar', mock_run.call_args[0][2])
+
+    @patch.object(pods_node_executor.common, 'run_interactive_command')
+    @patch.object(pods_node_executor.common, 'verify_pod_exists')
+    @patch.object(pods_node_executor.common, 'log_pod_parameters')
+    @patch.object(pods_node_executor.common, 'get_core_node_parameter_list')
+    @patch.object(pods_node_executor.common, 'connect')
+    def test_main_exits_when_command_reports_error(
+            self, mock_connect, mock_params, mock_log, mock_verify, mock_run):
+        os.environ['RD_CONFIG_SHELL'] = '/bin/bash'
+        os.environ['RD_CONFIG_COMMAND'] = 'false'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        mock_run.return_value = (MagicMock(), True)
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_node_executor.main()
+        self.assertEqual(1, cm.exception.code)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_node_executor.py
+++ b/contents/tests/test_pods_node_executor.py
@@ -81,6 +81,33 @@ class TestPodsNodeExecutor(unittest.TestCase):
 
         self.assertEqual('sidecar', mock_run.call_args[0][2])
 
+    @patch.object(pods_node_executor.common, 'verify_pod_exists')
+    @patch.object(pods_node_executor.common, 'log_pod_parameters')
+    @patch.object(pods_node_executor.common, 'get_core_node_parameter_list')
+    @patch.object(pods_node_executor.common, 'connect')
+    def test_main_exits_when_no_command_is_given(
+            self, mock_connect, mock_params, mock_log, mock_verify):
+        # Upstream indexed os.environ directly, so a missing command raised
+        # KeyError instead of telling the operator what was wrong.
+        os.environ['RD_CONFIG_SHELL'] = '/bin/bash'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_node_executor.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_node_executor.common, 'verify_pod_exists')
+    @patch.object(pods_node_executor.common, 'get_core_node_parameter_list')
+    @patch.object(pods_node_executor.common, 'connect')
+    def test_main_exits_when_pod_name_is_missing(
+            self, mock_connect, mock_params, mock_verify):
+        os.environ['RD_CONFIG_COMMAND'] = 'echo hello'
+        mock_params.return_value = [None, 'default', 'app']
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_node_executor.main()
+        self.assertEqual(1, cm.exception.code)
+
     @patch.object(pods_node_executor.common, 'run_interactive_command')
     @patch.object(pods_node_executor.common, 'verify_pod_exists')
     @patch.object(pods_node_executor.common, 'log_pod_parameters')

--- a/contents/tests/test_pods_read_logs.py
+++ b/contents/tests/test_pods_read_logs.py
@@ -64,6 +64,68 @@ class TestPodsReadLogs(unittest.TestCase):
     @patch.object(pods_read_logs.client, 'CoreV1Api')
     @patch.object(pods_read_logs.common, 'connect')
     @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_decodes_log_bytes_rather_than_printing_a_repr(
+            self, mock_params, mock_connect, mock_api_class):
+        mock_params.return_value = node_params()
+        mock_api_class.return_value.read_namespaced_pod_log.return_value.read.return_value = b'hello'
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_read_logs.main()
+
+        self.assertIn('hello', out.getvalue())
+        self.assertNotIn("b'hello'", out.getvalue())
+
+    @patch('kubernetes.watch.Watch')
+    @patch.object(pods_read_logs.client, 'CoreV1Api')
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_actually_follows_when_follow_is_requested(
+            self, mock_params, mock_connect, mock_api_class, mock_watch):
+        os.environ['RD_CONFIG_FOLLOW'] = 'true'
+        mock_params.return_value = node_params()
+        mock_watch.return_value.stream.return_value = ['line one']
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_read_logs.main()
+
+        kwargs = mock_watch.return_value.stream.call_args[1]
+        self.assertTrue(kwargs['follow'])
+        self.assertEqual('app', kwargs['container'])
+        self.assertIn('line one', out.getvalue())
+
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_exits_on_non_numeric_tail_lines(self, mock_params, mock_connect):
+        os.environ['RD_CONFIG_NUMBER_OF_LINES'] = 'lots'
+        mock_params.return_value = node_params()
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_read_logs.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_read_logs.client, 'CoreV1Api')
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_survives_non_utf8_container_output(
+            self, mock_params, mock_connect, mock_api_class):
+        # A UnicodeDecodeError is not an ApiException, so it would escape the
+        # try as an unhandled traceback and show the operator no logs at all.
+        mock_params.return_value = node_params()
+        mock_api_class.return_value.read_namespaced_pod_log.return_value.read.return_value = (
+            b'before \xff\xfe after')
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_read_logs.main()
+
+        self.assertIn('before', out.getvalue())
+        self.assertIn('after', out.getvalue())
+
+    @patch.object(pods_read_logs.client, 'CoreV1Api')
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
     def test_main_exits_on_api_exception(self, mock_params, mock_connect, mock_api_class):
         mock_params.return_value = node_params()
         mock_api_class.return_value.read_namespaced_pod_log.side_effect = ApiException(

--- a/contents/tests/test_pods_read_logs.py
+++ b/contents/tests/test_pods_read_logs.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for pods-read-logs.py.
+
+pods-read-logs.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pods_read_logs.common.
+"""
+
+import importlib
+import io
+import os
+import sys
+import unittest
+
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from kubernetes.client.rest import ApiException
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pods_read_logs = importlib.import_module('pods-read-logs')
+
+
+def node_params(name='my-pod', namespace='default', container='app'):
+    return {'name': name, 'namespace': namespace, 'container_name': container}
+
+class TestPodsReadLogs(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    @patch.object(pods_read_logs.client, 'CoreV1Api')
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_reads_logs_for_named_container(
+            self, mock_params, mock_connect, mock_api_class):
+        mock_params.return_value = node_params()
+        mock_api_class.return_value.read_namespaced_pod_log.return_value.read.return_value = b'line'
+
+        with redirect_stdout(io.StringIO()):
+            pods_read_logs.main()
+
+        kwargs = mock_api_class.return_value.read_namespaced_pod_log.call_args[1]
+        self.assertEqual('my-pod', kwargs['name'])
+        self.assertEqual('default', kwargs['namespace'])
+        self.assertEqual('app', kwargs['container'])
+
+    @patch.object(pods_read_logs.client, 'CoreV1Api')
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_reads_logs_without_a_container(
+            self, mock_params, mock_connect, mock_api_class):
+        mock_params.return_value = node_params(container=None)
+        mock_api_class.return_value.read_namespaced_pod_log.return_value.read.return_value = b'line'
+
+        with redirect_stdout(io.StringIO()):
+            pods_read_logs.main()
+
+        kwargs = mock_api_class.return_value.read_namespaced_pod_log.call_args[1]
+        self.assertNotIn('container', kwargs)
+
+    @patch.object(pods_read_logs.client, 'CoreV1Api')
+    @patch.object(pods_read_logs.common, 'connect')
+    @patch.object(pods_read_logs.common, 'get_code_node_parameter_dictionary')
+    def test_main_exits_on_api_exception(self, mock_params, mock_connect, mock_api_class):
+        mock_params.return_value = node_params()
+        mock_api_class.return_value.read_namespaced_pod_log.side_effect = ApiException(
+            status=404, reason='Not Found')
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_read_logs.main()
+        self.assertEqual(1, cm.exception.code)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_run_script.py
+++ b/contents/tests/test_pods_run_script.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for pods-run-script.py.
+
+pods-run-script.py has a hyphenated filename, so it is loaded with importlib. It does
+"import common", which resolves through the inserted sys.path to a module object
+distinct from contents.common, so patches target pods_run_script.common.
+"""
+
+import importlib
+import io
+import os
+import sys
+import unittest
+
+from contextlib import redirect_stdout
+from unittest.mock import MagicMock, patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+pods_run_script = importlib.import_module('pods-run-script')
+
+
+class TestPodsRunScript(unittest.TestCase):
+
+    def setUp(self):
+        os.environ.clear()
+
+    def _run_main(self, mock_run_command, mock_interactive, stdout=b'ok', stderr=b''):
+        resp = MagicMock()
+        resp.peek_stdout.return_value = bool(stdout)
+        resp.read_stdout.return_value = stdout
+        resp.peek_stderr.return_value = bool(stderr)
+        resp.read_stderr.return_value = stderr
+        mock_run_command.return_value = resp
+        mock_interactive.return_value = (resp, False)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            pods_run_script.main()
+        return out.getvalue()
+
+    @patch.object(pods_run_script.common, 'run_interactive_command')
+    @patch.object(pods_run_script.common, 'run_command')
+    @patch.object(pods_run_script.common, 'copy_file')
+    @patch.object(pods_run_script.common, 'log_pod_parameters')
+    @patch.object(pods_run_script.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_run_script.common, 'verify_pod_exists')
+    @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
+    @patch.object(pods_run_script.common, 'connect')
+    def test_main_copies_script_and_makes_it_executable(
+            self, mock_connect, mock_params, mock_verify, mock_api_class,
+            mock_log, mock_copy, mock_run_command, mock_interactive):
+        os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        mock_api_class.return_value.read_namespaced_pod.return_value = MagicMock()
+
+        output = self._run_main(mock_run_command, mock_interactive)
+
+        mock_copy.assert_called_once()
+        self.assertEqual('my-pod', mock_copy.call_args[1]['name'])
+        chmod = mock_run_command.call_args_list[0][1]['command']
+        self.assertEqual(['chmod', '+x'], chmod[:2])
+        self.assertIn('ok', output)
+
+    @patch.object(pods_run_script.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_run_script.common, 'verify_pod_exists')
+    @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
+    @patch.object(pods_run_script.common, 'connect')
+    def test_main_exits_when_pod_is_missing(
+            self, mock_connect, mock_params, mock_verify, mock_api_class):
+        os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        mock_api_class.return_value.read_namespaced_pod.return_value = None
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_run_script.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_run_script.common, 'run_interactive_command')
+    @patch.object(pods_run_script.common, 'run_command')
+    @patch.object(pods_run_script.common, 'copy_file')
+    @patch.object(pods_run_script.common, 'log_pod_parameters')
+    @patch.object(pods_run_script.client, 'CoreV1Api')
+    @patch.object(pods_run_script.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_run_script.common, 'verify_pod_exists')
+    @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
+    @patch.object(pods_run_script.common, 'connect')
+    def test_main_resolves_first_container_when_none_configured(
+            self, mock_connect, mock_params, mock_verify, mock_core_api,
+            mock_client_api, mock_log, mock_copy, mock_run_command, mock_interactive):
+        os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
+        mock_params.return_value = ['my-pod', 'default', None]
+        mock_core_api.return_value.read_namespaced_pod.return_value = MagicMock()
+        status = MagicMock()
+        status.spec.containers = [MagicMock()]
+        status.spec.containers[0].name = 'sidecar'
+        mock_client_api.return_value.read_namespaced_pod_status.return_value = status
+
+        self._run_main(mock_run_command, mock_interactive)
+
+        self.assertEqual('sidecar', mock_copy.call_args[1]['container'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/contents/tests/test_pods_run_script.py
+++ b/contents/tests/test_pods_run_script.py
@@ -15,6 +15,8 @@ import unittest
 from contextlib import redirect_stdout
 from unittest.mock import MagicMock, patch
 
+from kubernetes.client.rest import ApiException
+
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -43,7 +45,7 @@ class TestPodsRunScript(unittest.TestCase):
     @patch.object(pods_run_script.common, 'run_command')
     @patch.object(pods_run_script.common, 'copy_file')
     @patch.object(pods_run_script.common, 'log_pod_parameters')
-    @patch.object(pods_run_script.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_run_script.client, 'CoreV1Api')
     @patch.object(pods_run_script.common, 'verify_pod_exists')
     @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
     @patch.object(pods_run_script.common, 'connect')
@@ -62,7 +64,62 @@ class TestPodsRunScript(unittest.TestCase):
         self.assertEqual(['chmod', '+x'], chmod[:2])
         self.assertIn('ok', output)
 
-    @patch.object(pods_run_script.core_v1_api, 'CoreV1Api')
+    @patch.object(pods_run_script.common, 'delete_pod')
+    @patch.object(pods_run_script.common, 'run_interactive_command')
+    @patch.object(pods_run_script.common, 'run_command')
+    @patch.object(pods_run_script.common, 'copy_file')
+    @patch.object(pods_run_script.common, 'log_pod_parameters')
+    @patch.object(pods_run_script.client, 'CoreV1Api')
+    @patch.object(pods_run_script.common, 'verify_pod_exists')
+    @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
+    @patch.object(pods_run_script.common, 'connect')
+    def test_main_reports_but_survives_a_failed_cleanup(
+            self, mock_connect, mock_params, mock_verify, mock_api_class,
+            mock_log, mock_copy, mock_run_command, mock_interactive, mock_delete):
+        # Cleanup only runs because the script already failed. A failure to
+        # delete must not replace that with a traceback from the cleanup.
+        os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
+        os.environ['RD_CONFIG_DELETEONFAIL'] = 'true'
+        mock_params.return_value = ['my-pod', 'default', 'app']
+        resp = MagicMock()
+        resp.peek_stdout.return_value = False
+        resp.peek_stderr.return_value = False
+        mock_run_command.return_value = resp
+        mock_interactive.return_value = (resp, True)
+        mock_delete.side_effect = ApiException(status=500, reason='boom')
+
+        with redirect_stdout(io.StringIO()), self.assertRaises(SystemExit) as cm:
+            pods_run_script.main()
+
+        self.assertEqual(1, cm.exception.code)
+        mock_delete.assert_called_once()
+
+    @patch.object(pods_run_script.common, 'verify_pod_exists')
+    @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
+    @patch.object(pods_run_script.common, 'connect')
+    def test_main_exits_when_no_script_is_given(
+            self, mock_connect, mock_params, mock_verify):
+        # Upstream called .encode on the result of os.environ.get, so a missing
+        # script raised AttributeError on None rather than saying what was wrong.
+        mock_params.return_value = ['my-pod', 'default', 'app']
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_run_script.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_run_script.common, 'verify_pod_exists')
+    @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
+    @patch.object(pods_run_script.common, 'connect')
+    def test_main_exits_when_pod_name_is_missing(
+            self, mock_connect, mock_params, mock_verify):
+        os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
+        mock_params.return_value = [None, 'default', 'app']
+
+        with self.assertRaises(SystemExit) as cm:
+            pods_run_script.main()
+        self.assertEqual(1, cm.exception.code)
+
+    @patch.object(pods_run_script.client, 'CoreV1Api')
     @patch.object(pods_run_script.common, 'verify_pod_exists')
     @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
     @patch.object(pods_run_script.common, 'connect')
@@ -70,7 +127,7 @@ class TestPodsRunScript(unittest.TestCase):
             self, mock_connect, mock_params, mock_verify, mock_api_class):
         os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
         mock_params.return_value = ['my-pod', 'default', 'app']
-        mock_api_class.return_value.read_namespaced_pod.return_value = None
+        mock_verify.side_effect = SystemExit(1)
 
         with self.assertRaises(SystemExit) as cm:
             pods_run_script.main()
@@ -81,16 +138,14 @@ class TestPodsRunScript(unittest.TestCase):
     @patch.object(pods_run_script.common, 'copy_file')
     @patch.object(pods_run_script.common, 'log_pod_parameters')
     @patch.object(pods_run_script.client, 'CoreV1Api')
-    @patch.object(pods_run_script.core_v1_api, 'CoreV1Api')
     @patch.object(pods_run_script.common, 'verify_pod_exists')
     @patch.object(pods_run_script.common, 'get_core_node_parameter_list')
     @patch.object(pods_run_script.common, 'connect')
     def test_main_resolves_first_container_when_none_configured(
-            self, mock_connect, mock_params, mock_verify, mock_core_api,
-            mock_client_api, mock_log, mock_copy, mock_run_command, mock_interactive):
+            self, mock_connect, mock_params, mock_verify, mock_client_api,
+            mock_log, mock_copy, mock_run_command, mock_interactive):
         os.environ['RD_CONFIG_SCRIPT'] = 'echo hello'
         mock_params.return_value = ['my-pod', 'default', None]
-        mock_core_api.return_value.read_namespaced_pod.return_value = MagicMock()
         status = MagicMock()
         status.spec.containers = [MagicMock()]
         status.spec.containers[0].name = 'sidecar'


### PR DESCRIPTION
The pod step scripts had no test coverage at all. This adds it, and fixes
the defects that writing the tests exposed.

Two commits, deliberately ordered:

1. **Add tests for the step scripts** — tests only, no source changes. Passes
   against unmodified `main`, so it establishes a baseline rather than
   describing the fixes.
2. **Fix correctness bugs in the step scripts** — the fixes, each with a test.

Reviewing the first commit against `main` is a quick way to see what the
scripts do today; the second is where the behavior changes.

## Bugs fixed

**`pods-delete` reported success on a failed delete.** `common.delete_pod`
returns `None` on every failure path, and the caller ignored the return value,
so it printed "Pod deleted successfully" and exited 0 whether or not the pod
was deleted — the Rundeck job reported success either way.

**`pods-read-logs` never followed.** With Follow enabled it passed
`follow=False` to the watch stream. Its container branch was also inverted —
the container was omitted when one was configured, and passed as `None` when
one was not — and both output paths printed byte reprs (`b'line'`) rather than
log text. `tail_lines` was passed through as a string.

**`pods-create` announced success before checking the result**, so a falsy
response printed both that the pod was created and that it does not exist,
then exited 1. Its labels were parsed with `split('=')`, which raises an
unpacking `ValueError` on a value containing `=` and on an empty Labels
setting — which the UI permits, since `required` only rejects an unset value.

**`common.delete_pod` caught `Exception` and then read `e.status`**, raising
`AttributeError` for anything that is not an `ApiException`.

**`pods-copy-file` called `argparse.parse_args()` at import time** and never
used the result. Besides being dead, it consumed the caller's argv, which also
made the module impossible to import under a test runner.

Several scripts also failed obscurely on missing input — `.encode()` on `None`
for a missing script, `KeyError` for a missing command — rather than saying
what was wrong.

## Behaviour changes worth reviewing

`common.delete_pod` now returns `None` only for a 404 and raises otherwise.
Returning `None` for both left callers unable to distinguish an absent pod from
a failed delete, which is what allowed the bug above. **This changes an
existing contract, so `test_delete_pod_other_error` is updated to expect the
exception.**

Consequently `pods-delete` treats an absent pod as success: deleting is
idempotent, and a cleanup job that runs twice should not fail the second time.
Real failures now exit 1.

Each script gets its own logger name. `pod-describe`, `pods-node-executor`,
`pods-run-script` and `pods-copy-file` all logged as `kubernetes-model-source`,
the same name the resource model uses, and their format string prints
`%(name)s` — so container logs could not distinguish a failing run-script step
from a failing resource-model run. (`pods-read-logs` is renamed for consistency
only; it prints with `format="%(message)s"` so streamed pod logs are not
decorated, and its logger name never appears in output.)

## Notes

No new dependencies. Test count goes from 67 to 115; the added modules follow
the existing one-module-per-source-file convention.