### PR TITLE
Make the node model workload-aware so a job can run once per deployment

### DIFF
--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import datetime
 import logging
+import re
 import sys
 import os
 import common
@@ -18,6 +19,53 @@ logging.basicConfig(stream=sys.stderr,
 log = logging.getLogger('kubernetes-model-source')
 
 
+_TEMPLATE_TOKEN = re.compile(r'\$\{([^}]+)\}')
+
+# Default nodename template; reproduces the historical "<pod name>-<container name>".
+DEFAULT_NODENAME_FORMAT = '${default:name}-${default:container_name}'
+
+
+def _render_attribute_template(template, data):
+    # Substitute ${attribute} tokens with values from the node data dict, where
+    # attribute is any key present in data (e.g. default:name, labels:site,
+    # default:container_name). An attribute that is unknown, or known but unset,
+    # renders as an empty string -- an unscheduled pod has no podIP, and
+    # rendering that as "None" would put the word in the node name and give
+    # every such pod the same one.
+    def value(match):
+        attribute = data.get(match.group(1))
+        return '' if attribute is None else str(attribute)
+
+    return _TEMPLATE_TOKEN.sub(value, template)
+
+
+def render_nodename(data, config):
+    # An explicit nodename from Custom Mapping ("nodename.selector=default:name",
+    # the first example in the README) or from Default attributes wins. The
+    # template is the default naming strategy, not an override of the operator's
+    # -- overriding it would silently rename every node of an existing job.
+    if data.get('nodename'):
+        return data['nodename']
+
+    nodename_format = config.get('nodename_format') or DEFAULT_NODENAME_FORMAT
+    return _render_attribute_template(nodename_format, data)
+
+
+def workload_name(metadata, labels):
+    # Best-effort human-friendly workload name: the pod's controlling object, with
+    # the Deployment pod-template-hash stripped (e.g. "my-app-7f4b8bbfc6" -> "my-app").
+    # StatefulSets, DaemonSets and Jobs carry no such hash, so their owner name is used.
+    owner_refs = metadata.get('ownerReferences') or []
+    # Prefer controlling owner; fall back to first reference, then pod name.
+    owner = next((o for o in owner_refs if o.get('controller')),
+                 owner_refs[0] if owner_refs else None)
+    name = owner['name'] if owner else metadata['name']
+    pod_template_hash = labels.get('pod-template-hash')
+    if pod_template_hash and name.endswith('-' + pod_template_hash):
+        name = name[:-(len(pod_template_hash) + 1)]
+    return name
+
+
 def format_started_at(started):
     # With _preload_content=False the API's startedAt arrives as an RFC 3339 string
     # (e.g. "2024-06-15T10:30:00Z") rather than a datetime. Reformat it to the
@@ -32,7 +80,7 @@ def format_started_at(started):
         return None
 
 
-def nodeCollectData(pod, container, config):
+def nodeCollectData(pod, container, config, index=1):
     # config carries the per-run options parsed once in main() (tags, mappings,
     # defaults, emoticon flag, config file) so they are not re-parsed for every node.
     tags = config['tags']
@@ -81,6 +129,7 @@ def nodeCollectData(pod, container, config):
                 statusMessage = info.get('message')
 
     labels = []
+    workload = workload_name(metadata, pod_labels or {})
 
     if pod_labels:
         for keys, values in pod_labels.items():
@@ -94,6 +143,7 @@ def nodeCollectData(pod, container, config):
         'default:host_id': pod_status.get('hostIP'),
         'default:started_at': startedAt,
         'default:name': metadata['name'],
+        'default:workload': workload,
         'default:labels': ','.join(labels),
         'default:namespace': metadata['namespace'],
         'default:image': container.get('image'),
@@ -103,9 +153,21 @@ def nodeCollectData(pod, container, config):
         'default:container_name': container_name
     }
 
-    custom_attributes = {}
+    # rundeck attributes
+    data = default_settings
+    data['hostname'] = default_settings['default:pod_id']
+    data['terminated'] = terminated
 
-    # custom mapping attributes
+    # Add labels as its own map of node attributes.
+    if pod_labels is not None:
+        for key, value in pod_labels.items():
+            data['labels:' + key] = value
+
+    # Initialize custom attributes with ordinal position of this pod within its parent.
+    custom_attributes = {'index': index}
+
+    # Custom mapping attributes. Resolved after labels are merged so a mapping can
+    # name any node attribute as its source -- default:*, labels:*, hostname.
     if config['mappings']:
         log.debug('Mapping: %s', config['mappings'])
 
@@ -115,26 +177,12 @@ def nodeCollectData(pod, container, config):
             for key, value in mapping_array.items():
                 if ".selector" in key:
                     attribute = key.replace(".selector", "")
-                    custom_attribute = None
-                    # take the values from default
-                    if "default:" in value:
-                        custom_attribute = default_settings[value]
+                    custom_attribute = data.get(value)
 
                     if custom_attribute:
                         custom_attributes[attribute] = custom_attribute
 
         log.debug('Custom Attributes: %s', custom_attributes)
-
-    # rundeck attributes
-    data = default_settings
-    data['nodename'] = default_settings['default:name']+"-"+container_name
-    data['hostname'] = default_settings['default:pod_id']
-    data['terminated'] = terminated
-
-    # Add labels as its own map of node attributes.
-    if pod_labels is not None:
-        for key, value in pod_labels.items():
-            data['labels:' + key] = value
 
     emoticon = ""
     if default_settings['default:status'] == "running":
@@ -174,6 +222,10 @@ def nodeCollectData(pod, container, config):
 
     data.update(config['defaults'])
 
+    # nodename is left to the caller: main() renders it only once the pod is
+    # known to be kept and has its final index, so the template can reference
+    # ${index}. Any explicit nodename from Custom Mapping or Default attributes
+    # is already in data by this point and render_nodename honours it.
     return data
 
 
@@ -222,6 +274,8 @@ def main():
     if os.environ.get('RD_CONFIG_RUNNING') == 'true':
         running = True
 
+    one_per_workload = os.environ.get('RD_CONFIG_ONE_PER_WORKLOAD') == 'true'
+
     boEmoticon = False
     if os.environ.get('RD_CONFIG_EMOTICON') == 'true':
         boEmoticon = True
@@ -261,9 +315,16 @@ def main():
         'defaults': dict(token.split('=') for token in shlex.split(defaults or '')),
         'emoticon': boEmoticon,
         'config_file': os.environ.get('RD_CONFIG_CONFIG_FILE'),
+        'nodename_format': os.environ.get('RD_CONFIG_NODENAME_FORMAT'),
     }
 
     node_set = []
+
+    # Count child pods of a (possibly autoscaling) ReplicaSet or other parent.
+    # 'emitted' tracks which workloads have already contributed a node when
+    # one_per_workload is enabled.
+    parents = {}
+    emitted = set()
 
     try:
         ret = collect_pods_from_api(namespace_filter, label_selector,
@@ -275,22 +336,56 @@ def main():
         sys.exit(1)
 
     for i in ret:
+        metadata = i['metadata']
+        pod_name = metadata['name']
+        namespace = metadata['namespace']
+        labels = metadata.get('labels') or {}
+        workload = workload_name(metadata, labels)
         for container in i['spec']['containers']:
+            container_name = container['name']
             log.debug("%s\t%s\t%s\t%s",
                       i['status'].get('podIP'),
-                      i['metadata']['namespace'],
-                      i['metadata']['name'],
-                      container['name'])
+                      namespace,
+                      pod_name,
+                      container_name)
+
+            group = f"{namespace}/{workload}/{container_name}"
 
             node_data = nodeCollectData(i, container, config)
 
-            if running is False:
-                if node_data["terminated"] is False:
-                    node_set.append(node_data)
+            if running:
+                keep = node_data["status"].lower() == "running"
+            else:
+                keep = node_data["terminated"] is False
 
-            if running is True:
-                if node_data["status"].lower() == "running":
-                    node_set.append(node_data)
+            # With one_per_workload, emit only the first kept pod for each workload and
+            # container, so the node list shows a single entry per deployment.
+            if keep and one_per_workload:
+                if group in emitted:
+                    keep = False
+                else:
+                    emitted.add(group)
+
+            if not keep:
+                continue
+
+            # Number pods within their workload -- the owning Deployment/StatefulSet/etc.
+            # with the pod-template-hash stripped -- keyed per namespace and container so
+            # each container name gets its own sequence, and keeping templated node names
+            # unique while two ReplicaSets briefly coexist on a rollout.
+            #
+            # Numbering runs after the filter so a pod that is not emitted does not
+            # consume an index. Otherwise a workload whose first pod is Terminated emits
+            # nodes numbered 2 and 3, and "index == 1" -- the documented way to target a
+            # single replica -- matches nothing.
+            parents[group] = parents.get(group, 0) + 1
+            node_data['index'] = parents[group]
+
+            # Rendered here rather than in nodeCollectData so the template can reference
+            # ${index} after it is final.
+            node_data['nodename'] = render_nodename(node_data, config)
+
+            node_set.append(node_data)
 
     print(json.dumps(node_set, sort_keys=True))
 

--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -179,7 +179,12 @@ def nodeCollectData(pod, container, config, index=1):
                     attribute = key.replace(".selector", "")
                     custom_attribute = data.get(value)
 
-                    if custom_attribute:
+                    # `is not None` rather than a truth test: a Kubernetes label
+                    # may legitimately have an empty value, and dropping the
+                    # mapping in that case loses an attribute whose source does
+                    # exist. A missing source still resolves to None and is
+                    # skipped.
+                    if custom_attribute is not None:
                         custom_attributes[attribute] = custom_attribute
 
         log.debug('Custom Attributes: %s', custom_attributes)

--- a/contents/pods-resource-model.py
+++ b/contents/pods-resource-model.py
@@ -215,8 +215,21 @@ def nodeCollectData(pod, container, config, index=1):
 
     for tag in tags:
         if "tag.selector=" in tag:
-            custom_tag = data[tag.replace("tag.selector=", "")]
-            final_tags.append(custom_tag)
+            attribute = tag.replace("tag.selector=", "")
+            custom_tag = data.get(attribute)
+
+            # A selector naming an attribute this pod does not have -- a label
+            # only some pods carry, or an attribute that is legitimately unset,
+            # such as default:status_message on a healthy pod -- omits the tag
+            # for this node. Indexing instead raised KeyError out of main(), so
+            # a single unlabelled pod emptied the entire node source.
+            if custom_tag is None:
+                log.debug("No value for tag selector %r; tag omitted", attribute)
+                continue
+
+            # str() because not every node attribute is a string: terminated is
+            # a bool, and joining it raised TypeError.
+            final_tags.append(str(custom_tag))
         else:
             final_tags.append(tag)
 

--- a/contents/tests/test_pods_resource_model.py
+++ b/contents/tests/test_pods_resource_model.py
@@ -244,6 +244,35 @@ class TestNodeCollectData(unittest.TestCase):
                                'nope.selector=labels:does-not-exist', False)
         self.assertNotIn('nope', data)
 
+    def test_tag_selector_missing_attribute_omits_the_tag(self):
+        # A label only some pods carry must not take the whole node source down:
+        # indexing raised KeyError out of main() and no nodes were emitted at all.
+        container = make_container()
+        pod = make_pod(labels={'other': 'x'}, container_statuses=None)
+
+        data = nodeCollectData(pod, container, '',
+                               'kubernetes,tag.selector=labels:absent', None, False)
+        self.assertEqual('pods,kubernetes', data['tags'])
+
+    def test_tag_selector_unset_attribute_omits_the_tag(self):
+        # default:status_message is None on a healthy pod, so this selector
+        # failed on an entirely normal cluster.
+        container = make_container()
+        pod = make_pod(container_statuses=None)
+
+        data = nodeCollectData(pod, container, '',
+                               'kubernetes,tag.selector=default:status_message', None, False)
+        self.assertEqual('pods,kubernetes', data['tags'])
+
+    def test_tag_selector_non_string_attribute(self):
+        # terminated is a bool; joining it raised TypeError.
+        container = make_container()
+        pod = make_pod(container_statuses=None)
+
+        data = nodeCollectData(pod, container, '',
+                               'kubernetes,tag.selector=terminated', None, False)
+        self.assertEqual('pods,kubernetes,False', data['tags'])
+
     def test_status_message_in_description(self):
         container = make_container()
         condition = {

--- a/contents/tests/test_pods_resource_model.py
+++ b/contents/tests/test_pods_resource_model.py
@@ -224,6 +224,18 @@ class TestNodeCollectData(unittest.TestCase):
                                'service.selector=labels:app.kubernetes.io/service', False)
         self.assertEqual('checkout', data['service'])
 
+    def test_custom_mapping_keeps_an_empty_label_value(self):
+        # Kubernetes label values may be empty. A truth test on the resolved
+        # value dropped the mapping even though its source exists.
+        container = make_container()
+        pod = make_pod(labels={'app.kubernetes.io/component': ''},
+                       container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes',
+                               'component.selector=labels:app.kubernetes.io/component', False)
+        self.assertIn('component', data)
+        self.assertEqual('', data['component'])
+
     def test_custom_mapping_unknown_source_is_skipped(self):
         container = make_container()
         pod = make_pod(container_statuses=None)

--- a/contents/tests/test_pods_resource_model.py
+++ b/contents/tests/test_pods_resource_model.py
@@ -30,8 +30,13 @@ def nodeCollectData(pod, container, defaults, taglist, mappingList, boEmoticon):
         'defaults': dict(token.split('=') for token in shlex.split(defaults or '')),
         'emoticon': boEmoticon,
         'config_file': os.environ.get('RD_CONFIG_CONFIG_FILE'),
+        'nodename_format': os.environ.get('RD_CONFIG_NODENAME_FORMAT'),
     }
-    return _nodeCollectData(pod, container, config)
+    data = _nodeCollectData(pod, container, config)
+    # main() renders the nodename once the index is final; mirror that here so
+    # direct-call tests exercise the same naming path.
+    data['nodename'] = pods_resource_model.render_nodename(data, config)
+    return data
 
 
 # The resource model parses raw API JSON into plain dicts (camelCase keys), so
@@ -42,17 +47,32 @@ def make_container(name='app', image='nginx:latest'):
 
 def make_pod(name='my-pod', namespace='default', pod_ip='10.0.0.1',
              host_ip='192.168.1.1', phase='Running', labels=None,
-             container_statuses=None, conditions=None):
+             container_statuses=None, conditions=None, owner_references=None):
     status = {'phase': phase, 'podIP': pod_ip, 'hostIP': host_ip}
     if container_statuses is not None:
         status['containerStatuses'] = container_statuses
     if conditions is not None:
         status['conditions'] = conditions
+    metadata = {'name': name, 'namespace': namespace, 'labels': labels}
+    if owner_references is not None:
+        metadata['ownerReferences'] = owner_references
     return {
-        'metadata': {'name': name, 'namespace': namespace, 'labels': labels},
+        'metadata': metadata,
         'spec': {'containers': []},
         'status': status,
     }
+
+
+def make_deployment_pod(name, suffix, hash_='7f4b8bbfc6', container_statuses=None,
+                        namespace='default'):
+    # A pod owned by a Deployment's ReplicaSet, named <name>-<hash>-<suffix>.
+    return make_pod(
+        name=f'{name}-{hash_}-{suffix}',
+        namespace=namespace,
+        labels={'pod-template-hash': hash_},
+        owner_references=[{'kind': 'ReplicaSet', 'name': f'{name}-{hash_}', 'controller': True}],
+        container_statuses=container_statuses,
+    )
 
 
 def make_container_status(name='app', running=True, started_at=None,
@@ -192,6 +212,26 @@ class TestNodeCollectData(unittest.TestCase):
                                'hostname.selector=default:pod_id', False)
         self.assertEqual('10.0.0.1', data['hostname'])
 
+    def test_custom_mapping_from_label(self):
+        # A label key cannot be written as a ${...} token when it contains
+        # characters the operator would rather not repeat; a mapping gives it a
+        # short alias usable anywhere a node attribute is.
+        container = make_container()
+        pod = make_pod(labels={'app.kubernetes.io/service': 'checkout'},
+                       container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes',
+                               'service.selector=labels:app.kubernetes.io/service', False)
+        self.assertEqual('checkout', data['service'])
+
+    def test_custom_mapping_unknown_source_is_skipped(self):
+        container = make_container()
+        pod = make_pod(container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes',
+                               'nope.selector=labels:does-not-exist', False)
+        self.assertNotIn('nope', data)
+
     def test_status_message_in_description(self):
         container = make_container()
         condition = {
@@ -211,6 +251,103 @@ class TestNodeCollectData(unittest.TestCase):
 
         data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
         self.assertEqual('/etc/kube/config', data['kubernetes:config_file'])
+
+    def test_workload_strips_pod_template_hash(self):
+        container = make_container(name='web')
+        pod = make_deployment_pod('my-app', '2q2hd', container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('my-app', data['default:workload'])
+        # full pod name is still available for traceability
+        self.assertEqual('my-app-7f4b8bbfc6-2q2hd', data['default:name'])
+
+    def test_workload_falls_back_to_pod_name(self):
+        container = make_container(name='web')
+        pod = make_pod(name='lonely-pod', container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('lonely-pod', data['default:workload'])
+
+    def test_workload_prefers_controller_owner(self):
+        # A non-controller owner listed first must be ignored in favor of the controller.
+        container = make_container(name='web')
+        pod = make_pod(
+            name='my-app-7f4b8bbfc6-2q2hd',
+            labels={'pod-template-hash': '7f4b8bbfc6'},
+            owner_references=[
+                {'kind': 'Foo', 'name': 'some-other-owner'},
+                {'kind': 'ReplicaSet', 'name': 'my-app-7f4b8bbfc6', 'controller': True},
+            ],
+            container_statuses=None,
+        )
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('my-app', data['default:workload'])
+
+    def test_nodename_format_default(self):
+        container = make_container(name='web')
+        pod = make_pod(name='my-pod', container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('my-pod-web', data['nodename'])
+
+    def test_nodename_format_template_with_labels(self):
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = (
+            '${labels:site}-${labels:deployment_group}-${default:name}-${default:container_name}'
+        )
+        container = make_container(name='web')
+        pod = make_pod(name='my-pod',
+                       labels={'site': 'us-east', 'deployment_group': 'blue'},
+                       container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('us-east-blue-my-pod-web', data['nodename'])
+
+    def test_nodename_format_missing_attribute_is_blank(self):
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = '${labels:site}-${default:name}'
+        container = make_container(name='web')
+        pod = make_pod(name='my-pod', labels=None, container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('-my-pod', data['nodename'])
+
+    def test_nodename_workload_and_index(self):
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = '${default:workload}-${index}'
+        container = make_container(name='web')
+        pod = make_deployment_pod('my-app', '2q2hd', container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('my-app-1', data['nodename'])
+
+    def test_nodename_unset_attribute_renders_blank_not_none(self):
+        # An unscheduled pod has no podIP. Rendering that as "None" would put the
+        # word in the node name and give every pending pod the same one.
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = '${default:name}-${default:pod_id}'
+        container = make_container(name='web')
+        pod = make_pod(name='my-pod', pod_ip=None, container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes', None, False)
+        self.assertEqual('my-pod-', data['nodename'])
+
+    def test_explicit_nodename_mapping_wins_over_the_template(self):
+        # nodename.selector=default:name is the first example in the README, so
+        # the template must not silently rename the nodes of an existing job.
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = '${default:workload}-${index}'
+        container = make_container(name='web')
+        pod = make_deployment_pod('my-app', '2q2hd', container_statuses=None)
+
+        data = nodeCollectData(pod, container, '', 'kubernetes',
+                               'nodename.selector=default:name', False)
+        self.assertEqual('my-app-7f4b8bbfc6-2q2hd', data['nodename'])
+
+    def test_explicit_nodename_default_wins_over_the_template(self):
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = '${default:workload}-${index}'
+        container = make_container(name='web')
+        pod = make_deployment_pod('my-app', '2q2hd', container_statuses=None)
+
+        data = nodeCollectData(pod, container, 'nodename=fixed-name', 'kubernetes',
+                               None, False)
+        self.assertEqual('fixed-name', data['nodename'])
 
 
 class TestCollectPodsFromApi(unittest.TestCase):
@@ -557,6 +694,115 @@ class TestMain(unittest.TestCase):
         self.assertIn('401', joined_logs)
         self.assertIn('Unauthorized', joined_logs)
         self.assertIn('Invalid bearer token', joined_logs)
+
+    @patch.object(pods_resource_model, 'collect_pods_from_api')
+    @patch.object(pods_resource_model.common, 'connect')
+    def test_main_indexes_containers_within_parent(self, mock_connect, mock_collect):
+        os.environ['RD_CONFIG_TAGS'] = 'kubernetes'
+        os.environ['RD_CONFIG_ATTRIBUTES'] = ''
+
+        c1 = make_container(name='app')
+        c2 = make_container(name='sidecar')
+        statuses = [make_container_status(name='app', running=True),
+                    make_container_status(name='sidecar', running=True)]
+
+        # Pods are grouped by workload (owner minus pod-template-hash), so each
+        # container name gets its own sequence within a Deployment.
+        pods = [make_deployment_pod('rs', 'aaaaa', container_statuses=statuses),
+                make_deployment_pod('rs', 'bbbbb', container_statuses=statuses),
+                make_deployment_pod('other', 'ccccc', container_statuses=statuses)]
+
+        mock_collect.return_value = self._make_pod_list([(p, [c1, c2]) for p in pods])
+
+        with patch('builtins.print') as mock_print:
+            main()
+
+        import json
+        indexes = {n['nodename']: n['index'] for n in json.loads(mock_print.call_args[0][0])}
+        self.assertEqual(indexes['rs-7f4b8bbfc6-aaaaa-app'], 1)
+        self.assertEqual(indexes['rs-7f4b8bbfc6-aaaaa-sidecar'], 1)
+        self.assertEqual(indexes['rs-7f4b8bbfc6-bbbbb-app'], 2)
+        self.assertEqual(indexes['rs-7f4b8bbfc6-bbbbb-sidecar'], 2)
+        self.assertEqual(indexes['other-7f4b8bbfc6-ccccc-app'], 1)
+
+    @patch.object(pods_resource_model, 'collect_pods_from_api')
+    @patch.object(pods_resource_model.common, 'connect')
+    def test_main_replicas_indexed_by_workload(self, mock_connect, mock_collect):
+        # Three replicas of one Deployment get unique, hash-free numbered names.
+        # The template carries the namespace because the index is counted per
+        # namespace: without it, the same workload name in two namespaces would
+        # produce the same node name on an all-namespaces scan.
+        os.environ['RD_CONFIG_TAGS'] = 'kubernetes'
+        os.environ['RD_CONFIG_ATTRIBUTES'] = ''
+        os.environ['RD_CONFIG_NODENAME_FORMAT'] = (
+            '${default:namespace}-${default:workload}-${index}')
+
+        container = make_container(name='app')
+        cs = make_container_status(name='app', running=True)
+        mock_collect.return_value = self._make_pod_list([
+            (make_deployment_pod('my-app', suffix, container_statuses=[cs]), [container])
+            for suffix in ('2q2hd', 'h7m4k', 'z6ztb')
+        ])
+
+        with patch('builtins.print') as mock_print:
+            main()
+
+        import json
+        nodes = json.loads(mock_print.call_args[0][0])
+        self.assertEqual(['default-my-app-1', 'default-my-app-2', 'default-my-app-3'],
+                         [n['nodename'] for n in nodes])
+
+    @patch.object(pods_resource_model, 'collect_pods_from_api')
+    @patch.object(pods_resource_model.common, 'connect')
+    def test_main_numbers_only_the_pods_it_emits(self, mock_connect, mock_collect):
+        # A filtered-out pod must not consume an index, or a workload whose first
+        # pod is Terminated emits nodes numbered 2 and 3 and "index == 1" -- the
+        # documented way to target a single replica -- matches nothing.
+        os.environ['RD_CONFIG_TAGS'] = 'kubernetes'
+        os.environ['RD_CONFIG_ATTRIBUTES'] = ''
+
+        container = make_container(name='app')
+        gone = make_container_status(name='app', running=False, terminated=True)
+        live = make_container_status(name='app', running=True)
+        mock_collect.return_value = self._make_pod_list([
+            (make_deployment_pod('my-app', '2q2hd', container_statuses=[gone]), [container]),
+            (make_deployment_pod('my-app', 'h7m4k', container_statuses=[live]), [container]),
+            (make_deployment_pod('my-app', 'z6ztb', container_statuses=[live]), [container]),
+        ])
+
+        with patch('builtins.print') as mock_print:
+            main()
+
+        import json
+        nodes = json.loads(mock_print.call_args[0][0])
+        self.assertEqual([1, 2], sorted(n['index'] for n in nodes))
+
+    @patch.object(pods_resource_model, 'collect_pods_from_api')
+    @patch.object(pods_resource_model.common, 'connect')
+    def test_main_one_per_workload(self, mock_connect, mock_collect):
+        # With the toggle on, three replicas collapse to a single node, while the
+        # specific pod name stays available as default:name for kubectl traceability.
+        os.environ['RD_CONFIG_TAGS'] = 'kubernetes'
+        os.environ['RD_CONFIG_ATTRIBUTES'] = ''
+        os.environ['RD_CONFIG_ONE_PER_WORKLOAD'] = 'true'
+
+        container = make_container(name='app')
+        cs = make_container_status(name='app', running=True)
+        mock_collect.return_value = self._make_pod_list([
+            (make_deployment_pod('my-app', suffix, container_statuses=[cs]), [container])
+            for suffix in ('2q2hd', 'h7m4k', 'z6ztb')
+        ])
+
+        with patch('builtins.print') as mock_print:
+            main()
+
+        import json
+        nodes = json.loads(mock_print.call_args[0][0])
+        self.assertEqual(1, len(nodes))
+        self.assertEqual('my-app', nodes[0]['default:workload'])
+        self.assertEqual('my-app-7f4b8bbfc6-2q2hd', nodes[0]['default:name'])
+        self.assertEqual('default', nodes[0]['default:namespace'])
+        self.assertEqual('app', nodes[0]['default:container_name'])
 
 
 if __name__ == '__main__':

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -33,7 +33,7 @@ providers:
       - type: String
         name: tags
         title: Tags
-        description: 'You can add static and custom tags, eg: tag.selector=default:image'
+        description: 'You can add static and custom tags, eg: tag.selector=default:image. An unset attribute is omitted. Commas split a value into several tags: good for default:labels, wrong for free text like default:status_message.'
         default: 'tag.selector=default:status'
         renderingOptions:
           groupName: Config

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -40,7 +40,7 @@ providers:
       - type: String
         name: nodename_format
         title: 'Node Name Format'
-        description: 'Template for the node name. Reference any node attribute with ${...}: default:*, labels:*, index, or an alias defined in Custom Mapping. An attribute that is unset renders as an empty string. index counts the emitted pods within a workload in a single namespace, so include ${default:namespace} when scanning all namespaces or two namespaces running the same workload will produce the same node name. Ignored if a nodename is set explicitly through Custom Mapping or Default attributes. The full pod name remains available as default:name for traceability.'
+        description: 'Template for the node name. Reference any node attribute with ${...}: default:*, labels:*, index, or an alias defined in Custom Mapping. An attribute that is unset renders as an empty string. index counts the emitted pods within one namespace/workload/container group, so the template has to distinguish those dimensions itself: include ${default:namespace} when scanning more than one namespace, and ${default:container_name} for pods with more than one container. Omitting either lets two different pods render the same node name, and Rundeck keeps only one of them. Ignored if a nodename is set explicitly through Custom Mapping or Default attributes. The full pod name remains available as default:name for traceability.'
         default: '${default:name}-${default:container_name}'
         renderingOptions:
           groupName: Config
@@ -91,7 +91,7 @@ providers:
       - type: Boolean
         name: one_per_workload
         title: One Node Per Workload?
-        description: 'Emit a single node per workload (Deployment/StatefulSet/etc.) instead of one per pod, so a job runs once per deployment without every job needing an index filter. The emitted node keeps the first matching pod name in default:name; default:workload carries the stable workload name.'
+        description: 'Emit a single node per workload (Deployment/StatefulSet/etc.) instead of one per pod, so a job runs once per deployment without every job needing an index filter. One node is emitted per namespace/workload/container, so a multi-container pod still yields one node per container. The emitted node keeps the first matching pod name in default:name; default:workload carries the stable workload name.'
         default: "false"
         renderingOptions:
           groupName: Config

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -27,7 +27,7 @@ providers:
       - type: String
         name: mapping
         title: 'Custom Mapping'
-        description: 'Custom mapping, eg: nodename.selector=default:name'
+        description: 'Custom mapping, eg: nodename.selector=default:name. The source may be any node attribute: default:*, labels:*.'
         renderingOptions:
           groupName: Config
       - type: String
@@ -35,6 +35,13 @@ providers:
         title: Tags
         description: 'You can add static and custom tags, eg: tag.selector=default:image'
         default: 'tag.selector=default:status'
+        renderingOptions:
+          groupName: Config
+      - type: String
+        name: nodename_format
+        title: 'Node Name Format'
+        description: 'Template for the node name. Reference any node attribute with ${...}: default:*, labels:*, index, or an alias defined in Custom Mapping. An attribute that is unset renders as an empty string. index counts the emitted pods within a workload in a single namespace, so include ${default:namespace} when scanning all namespaces or two namespaces running the same workload will produce the same node name. Ignored if a nodename is set explicitly through Custom Mapping or Default attributes. The full pod name remains available as default:name for traceability.'
+        default: '${default:name}-${default:container_name}'
         renderingOptions:
           groupName: Config
       - name: namespace_filter
@@ -79,6 +86,13 @@ providers:
         name: running
         title: Just Running Pods?
         description: 'Filter for running pods'
+        renderingOptions:
+          groupName: Config
+      - type: Boolean
+        name: one_per_workload
+        title: One Node Per Workload?
+        description: 'Emit a single node per workload (Deployment/StatefulSet/etc.) instead of one per pod, so a job runs once per deployment without every job needing an index filter. The emitted node keeps the first matching pod name in default:name; default:workload carries the stable workload name.'
+        default: "false"
         renderingOptions:
           groupName: Config
       - type: Boolean


### PR DESCRIPTION
## The problem

A Deployment with three replicas produces three Rundeck nodes. For most jobs
that is exactly right — you want the command on every pod. But a large class of
maintenance work must run **once per deployment**, not once per pod, because the
replicas share state: a database migration, a cache rebuild, a data backfill, a
scheduled cleanup, anything that writes to the backend the replicas have in
common.

Running such a job on every pod is wasteful in the best case. In the worst case
it is a correctness bug: three replicas executing the same migration
concurrently against one database is a race that testing on a single-replica
environment will never reveal, and that surfaces in production as partial
writes, duplicate rows, or deadlocks.

## Why this cannot be expressed today

The resource model names each node `<pod name>-<container name>`, and exposes
the pod's labels. Neither gives you a way to select exactly one pod of a
deployment, durably:

- **Pod names are ephemeral.** `billing-7f4b8bbfc6-2q2hd` contains a
  pod-template-hash and a random suffix, both of which change on every rollout.
  A node filter naming a specific pod stops matching the next time you deploy.
- **Labels identify the group, not a member.** Filtering `labels:app = billing`
  selects all three replicas — which is the situation we are trying to avoid.

There is currently no stable identifier for "the deployment this pod belongs
to", and no deterministic way to pick one of its pods.

## What this adds

**`default:workload`** — the owning controller with the Deployment
pod-template-hash stripped, so `billing-7f4b8bbfc6-2q2hd` reports `billing`.
Derived from the pod's *controlling* ownerReference rather than by parsing the
pod name, falling back to the first reference and then the pod name, so
StatefulSets, DaemonSets, Jobs and bare pods all resolve sensibly. Unlike the
pod name, this survives rollouts.

**`index`** — an ordinal within `namespace/workload/container`, assigned only to
pods that are actually emitted, so a filtered-out Terminated pod does not
consume a number and `index == 1` always matches. Because the counter is scoped
per workload, one filter selects one pod from *each* deployment:

    3 deployments x 3 replicas = 9 nodes
    nodes matching  index == 1 : 3
         prod / billing   (billing-7f4b8bbfc6-aaaaa)
         prod / search    (search-7f4b8bbfc6-aaaaa)
      staging / billing   (billing-7f4b8bbfc6-aaaaa)

**One Node Per Workload** (`RD_CONFIG_ONE_PER_WORKLOAD`, default off) — does the
same thing at the model level for operators who would rather not rely on every
job remembering the filter. The node count then stays stable as replicas scale.

**Node Name Format** — node names become a `${attribute}` template, so they can
be built from the stable identity rather than the ephemeral pod name, for
example `${default:namespace}-${default:workload}`. The full pod name remains
available as `default:name` for traceability.

Custom Mapping sources now resolve against any node attribute rather than the
`default:*` set alone. That makes a label with an awkward key usable in a
template — `service.selector=labels:app.kubernetes.io/name`, then `${service}` —
and fixes mappings from `labels:` silently producing nothing.

## Compatibility

Both new behaviors are opt-in and the defaults reproduce today's output:

- The default template is `${default:name}-${default:container_name}`, which is
  the historical `<pod name>-<container name>` exactly.
- An explicit `nodename` from Custom Mapping or Default attributes still wins
  over the template, so the documented `nodename.selector=default:name` keeps
  working. Renaming a node makes Rundeck treat it as a different node, so this
  ordering matters.
- One Node Per Workload defaults to false; the node set is unchanged unless it
  is enabled.
- `default:workload` and `index` are additive attributes.

An unset attribute renders as an empty string rather than the literal `None`,
so a pending pod with no `podIP` cannot produce `my-app-None` — or give several
pending pods the same name.

## Testing

The resource-model suite goes from 33 to 49 tests, covering workload derivation
and controller-owner preference, per-workload numbering including the
filtered-pod case, the one-per-workload toggle, template rendering with labels
and unset attributes, explicit-nodename precedence, and mapping from a label.